### PR TITLE
A87 extract AWriter

### DIFF
--- a/ailets-rs/Cargo.toml
+++ b/ailets-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "actor_runtime", "actor_runtime_mocked", "areader", "cat", "gpt", "messages_to_markdown" ]
+members = [ "actor_runtime", "actor_runtime_mocked", "areader", "awriter", "cat", "gpt", "messages_to_markdown" ]
 resolver = "2"
 
 [workspace.package]

--- a/ailets-rs/actor_runtime_mocked/src/lib.rs
+++ b/ailets-rs/actor_runtime_mocked/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod rc_writer;
 pub mod vfs;
 
+pub use rc_writer::RcWriter;
 pub use vfs::{add_file, clear_mocks, get_file, IO_INTERRUPT, WANT_ERROR};

--- a/ailets-rs/actor_runtime_mocked/src/rc_writer.rs
+++ b/ailets-rs/actor_runtime_mocked/src/rc_writer.rs
@@ -1,3 +1,15 @@
+//! A writer implementation that stores written data in memory for later inspection.
+//!
+//! # Example
+//! ```
+//! use actor_runtime_mocked::RcWriter;
+//! use std::io::Write;
+//!
+//! let mut writer = RcWriter::new();
+//! writer.write_all(b"Hello, world!").unwrap();
+//! assert_eq!(writer.get_output(), "Hello, world!");
+//! ```
+
 use std::cell::RefCell;
 use std::io::{Result, Write};
 use std::rc::Rc;

--- a/ailets-rs/actor_runtime_mocked/src/rc_writer.rs
+++ b/ailets-rs/actor_runtime_mocked/src/rc_writer.rs
@@ -1,0 +1,32 @@
+use std::cell::RefCell;
+use std::io::{Result, Write};
+use std::rc::Rc;
+
+#[derive(Clone, Default)]
+pub struct RcWriter {
+    inner: Rc<RefCell<Vec<u8>>>,
+}
+
+impl Write for RcWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.inner.borrow_mut().write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.inner.borrow_mut().flush()
+    }
+}
+
+impl RcWriter {
+    #[must_use]
+    pub fn new() -> Self {
+        RcWriter {
+            inner: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+
+    #[must_use]
+    pub fn get_output(&self) -> String {
+        String::from_utf8_lossy(&self.inner.borrow()).to_string()
+    }
+}

--- a/ailets-rs/areader/Cargo.toml
+++ b/ailets-rs/areader/Cargo.toml
@@ -8,4 +8,3 @@ license.workspace = true
 [dependencies]
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
-lazy_static = "1.5.0"

--- a/ailets-rs/awriter/Cargo.toml
+++ b/ailets-rs/awriter/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "awriter"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
+actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }

--- a/ailets-rs/awriter/src/awriter.rs
+++ b/ailets-rs/awriter/src/awriter.rs
@@ -1,3 +1,23 @@
+//! A writer implementation for the actor runtime system.
+//!
+//! `AWriter` provides an implementation of the standard [`std::io::Write`] trait.
+//! It manages a file descriptor internally and ensures proper cleanup through the Drop trait.
+//!
+//! # Example
+//! ```no_run
+//! use std::io::Write;
+//! use awriter::AWriter;
+//!
+//! let mut writer = AWriter::new(c"example.txt").unwrap();
+//! writer.write_all(b"Hello, world!").unwrap();
+//! writer.close().unwrap();
+//! ```
+//!
+//! # Safety
+//! This module uses unsafe code to interact with the actor runtime's C FFI interface.
+//! The safety guarantees are maintained through proper file descriptor management
+//! and automatic cleanup in the Drop implementation.
+
 use std::ffi::CStr;
 use std::os::raw::{c_int, c_uint};
 

--- a/ailets-rs/awriter/src/awriter.rs
+++ b/ailets-rs/awriter/src/awriter.rs
@@ -53,7 +53,12 @@ impl std::io::Write for AWriter {
         if let Some(fd) = self.fd {
             let n = unsafe { awrite(fd, buf.as_ptr(), buf.len().try_into().unwrap()) };
             let n: usize = match n {
-                n if n <= 0 => panic!("Failed to write to output stream"),
+                n if n <= 0 => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("Failed to write to output stream {}", fd),
+                    ))
+                }
                 n => n.try_into().unwrap(),
             };
             Ok(n)

--- a/ailets-rs/awriter/src/awriter.rs
+++ b/ailets-rs/awriter/src/awriter.rs
@@ -28,6 +28,10 @@ pub struct AWriter {
 }
 
 impl AWriter {
+    /// Create a new `AWriter` instance for the specified file.
+    ///
+    /// # Errors
+    /// Returns an error if the file could not be created.
     pub fn new(filename: &CStr) -> Result<Self, std::io::Error> {
         let fd = unsafe { open_write(filename.as_ptr()) };
         if fd < 0 {

--- a/ailets-rs/awriter/src/awriter.rs
+++ b/ailets-rs/awriter/src/awriter.rs
@@ -9,9 +9,16 @@ pub struct AWriter {
 
 impl AWriter {
     #[must_use]
-    pub fn new(filename: &CStr) -> Self {
+    pub fn new(filename: &CStr) -> Result<Self, std::io::Error> {
         let fd = unsafe { open_write(filename.as_ptr()) };
-        AWriter { fd: Some(fd) }
+        if fd < 0 {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Failed to open file '{}'", filename.to_string_lossy()),
+            ))
+        } else {
+            Ok(AWriter { fd: Some(fd) })
+        }
     }
 }
 
@@ -37,8 +44,13 @@ impl std::io::Write for AWriter {
         }
     }
 
-
     fn flush(&mut self) -> std::io::Result<()> {
         Ok(())
+    }
+}
+
+impl std::fmt::Debug for AWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AWriter").field("fd", &self.fd).finish()
     }
 }

--- a/ailets-rs/awriter/src/awriter.rs
+++ b/ailets-rs/awriter/src/awriter.rs
@@ -1,0 +1,41 @@
+use std::ffi::CStr;
+use std::os::raw::c_int;
+
+use actor_runtime::{aclose, awrite, open_write};
+
+pub struct AWriter {
+    fd: Option<c_int>,
+}
+
+impl AWriter {
+    #[must_use]
+    pub fn new(filename: &CStr) -> Self {
+        let fd = unsafe { open_write(filename.as_ptr()) };
+        AWriter { fd: Some(fd) }
+    }
+}
+
+impl Drop for AWriter {
+    fn drop(&mut self) {
+        if let Some(fd) = self.fd.take() {
+            unsafe { aclose(fd) };
+        }
+    }
+}
+
+impl std::io::Write for AWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if let Some(fd) = self.fd {
+            unsafe {
+                awrite(fd, buf.as_ptr(), u32::try_from(buf.len()).unwrap());
+            }
+            Ok(buf.len())
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}

--- a/ailets-rs/awriter/src/lib.rs
+++ b/ailets-rs/awriter/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod awriter;
+
+pub use awriter::AWriter;
+

--- a/ailets-rs/awriter/src/lib.rs
+++ b/ailets-rs/awriter/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod awriter;
 
 pub use awriter::AWriter;
-

--- a/ailets-rs/awriter/tests/awriter_test.rs
+++ b/ailets-rs/awriter/tests/awriter_test.rs
@@ -1,0 +1,14 @@
+use actor_runtime_mocked::clear_mocks;
+use awriter::AWriter;
+
+#[test]
+fn cant_open_nonexistent_file() {
+    clear_mocks();
+
+    let err = AWriter::new(c"file-name-to-fail\u{1}").expect_err("Should fail to create writer");
+
+    assert!(
+        err.to_string().contains("file-name-to-fail\u{1}"),
+        "Error message should contain the file name"
+    );
+}

--- a/ailets-rs/awriter/tests/awriter_test.rs
+++ b/ailets-rs/awriter/tests/awriter_test.rs
@@ -1,7 +1,17 @@
-use actor_runtime_mocked::clear_mocks;
-use actor_runtime_mocked::WANT_ERROR;
+use actor_runtime_mocked::{clear_mocks, get_file, WANT_ERROR};
 use awriter::AWriter;
 use std::io::Write;
+
+#[test]
+fn happy_path() {
+    clear_mocks();
+    let mut writer = AWriter::new(c"test").expect("Should create writer");
+
+    writer.write_all(b"Hello,").unwrap();
+    writer.write_all(b" world!").unwrap();
+
+    assert_eq!(get_file("test").unwrap(), b"Hello, world!");
+}
 
 #[test]
 fn cant_open_nonexistent_file() {

--- a/ailets-rs/awriter/tests/awriter_test.rs
+++ b/ailets-rs/awriter/tests/awriter_test.rs
@@ -14,6 +14,24 @@ fn happy_path() {
 }
 
 #[test]
+fn write_in_chunks() {
+    clear_mocks();
+    let mut writer = AWriter::new(c"test").expect("Should create writer");
+
+    let data = b"one\ntwo\nthree\n";
+    for _ in 0..3 {
+        let n = writer.write(data).unwrap();
+        assert!(n == 4, "Should write 4 bytes (o, n, e, nl)");
+    }
+    writer.write_all(data).unwrap();
+
+    assert_eq!(
+        get_file("test").unwrap(),
+        b"one\none\none\none\ntwo\nthree\n"
+    );
+}
+
+#[test]
 fn cant_open_nonexistent_file() {
     clear_mocks();
 

--- a/ailets-rs/awriter/tests/awriter_test.rs
+++ b/ailets-rs/awriter/tests/awriter_test.rs
@@ -1,5 +1,7 @@
 use actor_runtime_mocked::clear_mocks;
+use actor_runtime_mocked::WANT_ERROR;
 use awriter::AWriter;
+use std::io::Write;
 
 #[test]
 fn cant_open_nonexistent_file() {
@@ -21,4 +23,19 @@ fn close_can_raise_error() {
 
     clear_mocks();
     writer.close().expect_err("Should fail to close");
+}
+
+#[test]
+fn write_error() {
+    clear_mocks();
+
+    let mut writer = AWriter::new(c"fname-write-error").expect("Should create writer");
+    let err = writer
+        .write(&[WANT_ERROR as u8])
+        .expect_err("Should fail to write");
+
+    assert!(
+        err.to_string().contains("Failed to write"),
+        "Error message should indicate write failure"
+    );
 }

--- a/ailets-rs/awriter/tests/awriter_test.rs
+++ b/ailets-rs/awriter/tests/awriter_test.rs
@@ -12,3 +12,13 @@ fn cant_open_nonexistent_file() {
         "Error message should contain the file name"
     );
 }
+
+#[test]
+fn close_can_raise_error() {
+    clear_mocks();
+
+    let mut writer = AWriter::new(c"fname-close-error").expect("Should create writer");
+
+    clear_mocks();
+    writer.close().expect_err("Should fail to close");
+}

--- a/ailets-rs/gpt/Cargo.toml
+++ b/ailets-rs/gpt/Cargo.toml
@@ -14,3 +14,4 @@ scan_json = "1.0.0"
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 areader = { version = "0.1.0", path = "../areader" }
 awriter = { version = "0.1.0", path = "../awriter" }
+actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }

--- a/ailets-rs/gpt/Cargo.toml
+++ b/ailets-rs/gpt/Cargo.toml
@@ -13,5 +13,4 @@ getrandom = { version = "0.2", features = ["custom"] }
 scan_json = "1.0.0"
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 areader = { version = "0.1.0", path = "../areader" }
-actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 awriter = { version = "0.1.0", path = "../awriter" }

--- a/ailets-rs/gpt/Cargo.toml
+++ b/ailets-rs/gpt/Cargo.toml
@@ -14,3 +14,4 @@ scan_json = "1.0.0"
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 areader = { version = "0.1.0", path = "../areader" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
+awriter = { version = "0.1.0", path = "../awriter" }

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -45,8 +45,8 @@ pub fn on_content(
 
     let mut builder = builder_cell.borrow_mut();
     builder.begin_text_chunk();
-    let awriter = builder.get_awriter();
-    let wb = rjiter.write_long_bytes(awriter);
+    let writer = builder.get_writer();
+    let wb = rjiter.write_long_bytes(writer);
     assert!(wb.is_ok(), "Error on the content item level: {wb:?}");
     StreamOp::ValueIsConsumed
 }
@@ -54,9 +54,10 @@ pub fn on_content(
 type BA<'a> = BoxedAction<'a, StructureBuilder>;
 
 #[allow(clippy::missing_panics_doc)]
-pub fn _process_gpt(mut reader: impl std::io::Read) {
-    let awriter = AWriter::new(c"");
-    let builder_cell = RefCell::new(StructureBuilder::new(awriter));
+pub fn _process_gpt(mut reader: impl std::io::Read, mut writer: impl std::io::Write) {
+    let writer = Box::new(writer);
+    let builder = StructureBuilder::new(writer);
+    let builder_cell = RefCell::new(builder);
 
     let mut buffer = vec![0u8; BUFFER_SIZE as usize];
 
@@ -119,5 +120,6 @@ pub fn _process_gpt(mut reader: impl std::io::Read) {
 #[allow(clippy::missing_panics_doc)]
 pub extern "C" fn process_gpt() {
     let reader = AReader::new(c"").unwrap();
-    _process_gpt(reader);
+    let writer = AWriter::new(c"");
+    _process_gpt(reader, writer);
 }

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -65,7 +65,7 @@ type BA<'a, W> = BoxedAction<'a, StructureBuilder<W>>;
 #[allow(clippy::missing_panics_doc)]
 pub fn _process_gpt<W: Write>(
     mut reader: impl std::io::Read,
-    mut writer: W,
+    writer: W,
 ) {
     let builder = StructureBuilder::new(writer);
     let builder_cell = RefCell::new(builder);

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -63,10 +63,7 @@ pub fn on_content<W: Write>(
 type BA<'a, W> = BoxedAction<'a, StructureBuilder<W>>;
 
 #[allow(clippy::missing_panics_doc)]
-pub fn _process_gpt<W: Write>(
-    mut reader: impl std::io::Read,
-    writer: W,
-) {
+pub fn _process_gpt<W: Write>(mut reader: impl std::io::Read, writer: W) {
     let builder = StructureBuilder::new(writer);
     let builder_cell = RefCell::new(builder);
 
@@ -131,6 +128,6 @@ pub fn _process_gpt<W: Write>(
 #[allow(clippy::missing_panics_doc)]
 pub extern "C" fn process_gpt() {
     let reader = AReader::new(c"").unwrap();
-    let writer = AWriter::new(c"");
+    let writer = AWriter::new(c"").unwrap();
     _process_gpt(reader, writer);
 }

--- a/ailets-rs/gpt/src/structure_builder.rs
+++ b/ailets-rs/gpt/src/structure_builder.rs
@@ -1,17 +1,17 @@
 use std::io::Write;
 
 #[allow(clippy::struct_excessive_bools)]
-pub struct StructureBuilder {
-    writer: Box<dyn std::io::Write>,
+pub struct StructureBuilder<W: Write> {
+    writer: W,
     message_has_role: bool,
     message_has_content: bool,
     text_is_open: bool,
     message_is_closed: bool,
 }
 
-impl StructureBuilder {
+impl<W: Write> StructureBuilder<W> {
     #[must_use]
-    pub fn new(writer: Box<dyn std::io::Write>) -> Self {
+    pub fn new(writer: W) -> Self {
         StructureBuilder {
             writer,
             message_has_role: false,
@@ -22,7 +22,7 @@ impl StructureBuilder {
     }
 
     #[must_use]
-    pub fn get_writer(&mut self) -> &mut Box<dyn std::io::Write> {
+    pub fn get_writer(&mut self) -> &mut W {
         &mut self.writer
     }
 

--- a/ailets-rs/gpt/src/structure_builder.rs
+++ b/ailets-rs/gpt/src/structure_builder.rs
@@ -1,9 +1,8 @@
 use std::io::Write;
-use awriter::AWriter;
 
 #[allow(clippy::struct_excessive_bools)]
 pub struct StructureBuilder {
-    awriter: AWriter,
+    writer: Box<dyn std::io::Write>,
     message_has_role: bool,
     message_has_content: bool,
     text_is_open: bool,
@@ -12,9 +11,9 @@ pub struct StructureBuilder {
 
 impl StructureBuilder {
     #[must_use]
-    pub fn new(awriter: AWriter) -> Self {
+    pub fn new(writer: Box<dyn std::io::Write>) -> Self {
         StructureBuilder {
-            awriter,
+            writer,
             message_has_role: false,
             message_has_content: false,
             text_is_open: false,
@@ -23,8 +22,8 @@ impl StructureBuilder {
     }
 
     #[must_use]
-    pub fn get_awriter(&mut self) -> &mut AWriter {
-        &mut self.awriter
+    pub fn get_writer(&mut self) -> &mut Box<dyn std::io::Write> {
+        &mut self.writer
     }
 
     pub fn begin_message(&mut self) {
@@ -89,6 +88,6 @@ impl StructureBuilder {
 
     #[allow(clippy::missing_panics_doc)]
     pub fn str(&mut self, text: &str) {
-        self.awriter.write_all(text.as_bytes()).unwrap();
+        self.writer.write_all(text.as_bytes()).unwrap();
     }
 }

--- a/ailets-rs/gpt/src/structure_builder.rs
+++ b/ailets-rs/gpt/src/structure_builder.rs
@@ -3,7 +3,7 @@ use std::ffi::CStr;
 use actor_runtime::{aclose, awrite, open_write};
 
 #[allow(clippy::struct_excessive_bools)]
-pub struct AWriter {
+pub struct StructureBuilder {
     fd: Option<i32>,
     message_has_role: bool,
     message_has_content: bool,
@@ -25,11 +25,11 @@ fn escape_json_value(s: &str) -> &str {
 }
 */
 
-impl AWriter {
+impl StructureBuilder {
     #[must_use]
     pub fn new(filename: &CStr) -> Self {
         let fd = unsafe { open_write(filename.as_ptr()) };
-        AWriter {
+        StructureBuilder {
             fd: Some(fd),
             message_has_role: false,
             message_has_content: false,
@@ -109,7 +109,7 @@ impl AWriter {
     }
 }
 
-impl Drop for AWriter {
+impl Drop for StructureBuilder {
     fn drop(&mut self) {
         if let Some(fd) = self.fd.take() {
             unsafe { aclose(fd) };
@@ -117,7 +117,7 @@ impl Drop for AWriter {
     }
 }
 
-impl std::io::Write for AWriter {
+impl std::io::Write for StructureBuilder {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if let Some(fd) = self.fd {
             unsafe {

--- a/ailets-rs/gpt/tests/response_to_messages.rs
+++ b/ailets-rs/gpt/tests/response_to_messages.rs
@@ -1,5 +1,9 @@
 use gpt::_process_gpt;
 use std::io::Cursor;
+use std::io::Result;
+use std::rc::Rc;
+use std::io::Write;
+use std::borrow::BorrowMut;
 
 fn get_expected_basic_message() -> String {
     "{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\
@@ -7,27 +11,56 @@ fn get_expected_basic_message() -> String {
         .to_string()
 }
 
+#[derive(Clone)]
+struct RcWriter {
+    inner: Rc<Vec<u8>>,
+}
+
+impl Write for RcWriter {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        Rc::get_mut(&mut self.inner).unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Rc::get_mut(&mut self.inner).unwrap().flush()
+    }
+}
+
+impl RcWriter {
+    fn new() -> Self {
+        RcWriter {
+            inner: Rc::new(Vec::new()),
+        }
+    }
+
+    fn get_output(&self) -> String {
+        String::from_utf8_lossy(self.inner.as_slice()).to_string()
+    }
+}
+
+
 #[test]
 fn test_basic_processing() {
     let fixture_content = std::fs::read_to_string("tests/fixture/basic_response.txt")
         .expect("Failed to read fixture file 'basic_response.txt'");
     let reader = Cursor::new(fixture_content);
+    let writer = RcWriter::new();
 
-    _process_gpt(reader);
+    _process_gpt(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
+    let result = writer.get_output();
     assert_eq!(result, get_expected_basic_message());
 }
 
 #[test]
 fn test_streaming() {
-    clear_mocks();
     let fixture_content = std::fs::read_to_string("tests/fixture/basic_streaming.txt")
         .expect("Failed to read fixture file 'basic_streaming.txt'");
     let reader = Cursor::new(fixture_content);
+    let writer = RcWriter::new();
 
-    _process_gpt(reader);
+    _process_gpt(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
+    let result = writer.get_output();
     assert_eq!(result, get_expected_basic_message());
 }

--- a/ailets-rs/gpt/tests/response_to_messages.rs
+++ b/ailets-rs/gpt/tests/response_to_messages.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use std::io::Result;
 use std::rc::Rc;
 use std::io::Write;
-use std::borrow::BorrowMut;
+use std::cell::RefCell;
 
 fn get_expected_basic_message() -> String {
     "{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\
@@ -13,28 +13,28 @@ fn get_expected_basic_message() -> String {
 
 #[derive(Clone)]
 struct RcWriter {
-    inner: Rc<Vec<u8>>,
+    inner: Rc<RefCell<Vec<u8>>>,
 }
 
 impl Write for RcWriter {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        Rc::get_mut(&mut self.inner).unwrap().write(buf)
+        self.inner.borrow_mut().write(buf)
     }
 
     fn flush(&mut self) -> Result<()> {
-        Rc::get_mut(&mut self.inner).unwrap().flush()
+        self.inner.borrow_mut().flush()
     }
 }
 
 impl RcWriter {
     fn new() -> Self {
         RcWriter {
-            inner: Rc::new(Vec::new()),
+            inner: Rc::new(RefCell::new(Vec::new())),
         }
     }
 
     fn get_output(&self) -> String {
-        String::from_utf8_lossy(self.inner.as_slice()).to_string()
+        String::from_utf8_lossy(&self.inner.borrow()).to_string()
     }
 }
 

--- a/ailets-rs/gpt/tests/response_to_messages.rs
+++ b/ailets-rs/gpt/tests/response_to_messages.rs
@@ -1,4 +1,3 @@
-use actor_runtime_mocked::{clear_mocks, get_file};
 use gpt::_process_gpt;
 use std::io::Cursor;
 
@@ -10,7 +9,6 @@ fn get_expected_basic_message() -> String {
 
 #[test]
 fn test_basic_processing() {
-    clear_mocks();
     let fixture_content = std::fs::read_to_string("tests/fixture/basic_response.txt")
         .expect("Failed to read fixture file 'basic_response.txt'");
     let reader = Cursor::new(fixture_content);

--- a/ailets-rs/gpt/tests/response_to_messages.rs
+++ b/ailets-rs/gpt/tests/response_to_messages.rs
@@ -1,43 +1,12 @@
+use actor_runtime_mocked::RcWriter;
 use gpt::_process_gpt;
 use std::io::Cursor;
-use std::io::Result;
-use std::rc::Rc;
-use std::io::Write;
-use std::cell::RefCell;
 
 fn get_expected_basic_message() -> String {
     "{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\
     \"Hello! How can I assist you today?\"}]}\n"
         .to_string()
 }
-
-#[derive(Clone)]
-struct RcWriter {
-    inner: Rc<RefCell<Vec<u8>>>,
-}
-
-impl Write for RcWriter {
-    fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.inner.borrow_mut().write(buf)
-    }
-
-    fn flush(&mut self) -> Result<()> {
-        self.inner.borrow_mut().flush()
-    }
-}
-
-impl RcWriter {
-    fn new() -> Self {
-        RcWriter {
-            inner: Rc::new(RefCell::new(Vec::new())),
-        }
-    }
-
-    fn get_output(&self) -> String {
-        String::from_utf8_lossy(&self.inner.borrow()).to_string()
-    }
-}
-
 
 #[test]
 fn test_basic_processing() {
@@ -48,8 +17,7 @@ fn test_basic_processing() {
 
     _process_gpt(reader, writer.clone());
 
-    let result = writer.get_output();
-    assert_eq!(result, get_expected_basic_message());
+    assert_eq!(writer.get_output(), get_expected_basic_message());
 }
 
 #[test]
@@ -61,6 +29,5 @@ fn test_streaming() {
 
     _process_gpt(reader, writer.clone());
 
-    let result = writer.get_output();
-    assert_eq!(result, get_expected_basic_message());
+    assert_eq!(writer.get_output(), get_expected_basic_message());
 }

--- a/ailets-rs/gpt/tests/sse_handler_test.rs
+++ b/ailets-rs/gpt/tests/sse_handler_test.rs
@@ -3,7 +3,7 @@ use std::io;
 
 use actor_runtime_mocked::{clear_mocks, get_file};
 
-use gpt::awriter::AWriter;
+use gpt::structure_builder::StructureBuilder;
 use gpt::{on_content, on_role};
 use scan_json::RJiter;
 
@@ -16,13 +16,13 @@ fn basic_pass() {
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
     let rjiter_cell = RefCell::new(rjiter);
-    let awriter = AWriter::new(c"");
-    let awriter_cell = RefCell::new(awriter);
+    let builder = StructureBuilder::new(c"");
+    let builder_cell = RefCell::new(builder);
 
     // Act
-    on_role(&rjiter_cell, &awriter_cell);
-    on_content(&rjiter_cell, &awriter_cell);
-    awriter_cell.borrow_mut().end_message();
+    on_role(&rjiter_cell, &builder_cell);
+    on_content(&rjiter_cell, &builder_cell);
+    builder_cell.borrow_mut().end_message();
 
     // Assert
     let expected =
@@ -39,16 +39,16 @@ fn join_multiple_content_deltas() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(c"");
     let rjiter_cell = RefCell::new(rjiter);
-    let awriter_cell = RefCell::new(awriter);
+    let builder_cell = RefCell::new(builder);
 
     // Act
-    on_role(&rjiter_cell, &awriter_cell);
-    on_content(&rjiter_cell, &awriter_cell);
-    on_content(&rjiter_cell, &awriter_cell);
-    on_content(&rjiter_cell, &awriter_cell);
-    awriter_cell.borrow_mut().end_message();
+    on_role(&rjiter_cell, &builder_cell);
+    on_content(&rjiter_cell, &builder_cell);
+    on_content(&rjiter_cell, &builder_cell);
+    on_content(&rjiter_cell, &builder_cell);
+    builder_cell.borrow_mut().end_message();
 
     // Assert
     let expected =
@@ -65,15 +65,15 @@ fn ignore_additional_role() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(c"");
     let rjiter_cell = RefCell::new(rjiter);
-    let awriter_cell = RefCell::new(awriter);
+    let builder_cell = RefCell::new(builder);
 
     // Act
-    on_role(&rjiter_cell, &awriter_cell);
-    on_role(&rjiter_cell, &awriter_cell);
-    on_role(&rjiter_cell, &awriter_cell);
-    awriter_cell.borrow_mut().end_message();
+    on_role(&rjiter_cell, &builder_cell);
+    on_role(&rjiter_cell, &builder_cell);
+    on_role(&rjiter_cell, &builder_cell);
+    builder_cell.borrow_mut().end_message();
 
     // Assert
     let expected = r#"{"role":"a1","content":[]}"#.to_owned() + "\n";
@@ -89,13 +89,13 @@ fn create_message_without_input_role() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(c"");
     let rjiter_cell = RefCell::new(rjiter);
-    let awriter_cell = RefCell::new(awriter);
+    let builder_cell = RefCell::new(builder);
 
     // Act
-    on_content(&rjiter_cell, &awriter_cell);
-    awriter_cell.borrow_mut().end_message();
+    on_content(&rjiter_cell, &builder_cell);
+    builder_cell.borrow_mut().end_message();
 
     // Assert
     let expected =
@@ -112,15 +112,15 @@ fn can_call_end_message_multiple_times() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(c"");
     let rjiter_cell = RefCell::new(rjiter);
-    let awriter_cell = RefCell::new(awriter);
+    let builder_cell = RefCell::new(builder);
 
     // Act
-    on_content(&rjiter_cell, &awriter_cell);
-    awriter_cell.borrow_mut().end_message();
-    awriter_cell.borrow_mut().end_message();
-    awriter_cell.borrow_mut().end_message();
+    on_content(&rjiter_cell, &builder_cell);
+    builder_cell.borrow_mut().end_message();
+    builder_cell.borrow_mut().end_message();
+    builder_cell.borrow_mut().end_message();
 
     // Assert
     let expected =

--- a/ailets-rs/gpt/tests/sse_handler_test.rs
+++ b/ailets-rs/gpt/tests/sse_handler_test.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::io;
 
 use actor_runtime_mocked::{clear_mocks, get_file};
-
+use awriter::AWriter;
 use gpt::structure_builder::StructureBuilder;
 use gpt::{on_content, on_role};
 use scan_json::RJiter;
@@ -16,7 +16,8 @@ fn basic_pass() {
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
     let rjiter_cell = RefCell::new(rjiter);
-    let builder = StructureBuilder::new(c"");
+    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(awriter);
     let builder_cell = RefCell::new(builder);
 
     // Act
@@ -39,7 +40,8 @@ fn join_multiple_content_deltas() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let builder = StructureBuilder::new(c"");
+    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(awriter);
     let rjiter_cell = RefCell::new(rjiter);
     let builder_cell = RefCell::new(builder);
 
@@ -65,7 +67,8 @@ fn ignore_additional_role() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let builder = StructureBuilder::new(c"");
+    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(awriter);
     let rjiter_cell = RefCell::new(rjiter);
     let builder_cell = RefCell::new(builder);
 
@@ -89,7 +92,8 @@ fn create_message_without_input_role() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let builder = StructureBuilder::new(c"");
+    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(awriter);
     let rjiter_cell = RefCell::new(rjiter);
     let builder_cell = RefCell::new(builder);
 
@@ -112,7 +116,8 @@ fn can_call_end_message_multiple_times() {
     let mut buffer = vec![0u8; 16];
     let mut cursor = io::Cursor::new(input);
     let rjiter = RJiter::new(&mut cursor, &mut buffer);
-    let builder = StructureBuilder::new(c"");
+    let awriter = AWriter::new(c"");
+    let builder = StructureBuilder::new(awriter);
     let rjiter_cell = RefCell::new(rjiter);
     let builder_cell = RefCell::new(builder);
 

--- a/ailets-rs/messages_to_markdown/Cargo.toml
+++ b/ailets-rs/messages_to_markdown/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
+actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 areader = { version = "0.1.0", path = "../areader" }
 awriter = { version = "0.1.0", path = "../awriter" }
 getrandom = { version = "0.2", features = ["custom"] }

--- a/ailets-rs/messages_to_markdown/Cargo.toml
+++ b/ailets-rs/messages_to_markdown/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
-actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 areader = { version = "0.1.0", path = "../areader" }
 awriter = { version = "0.1.0", path = "../awriter" }
 getrandom = { version = "0.2", features = ["custom"] }

--- a/ailets-rs/messages_to_markdown/Cargo.toml
+++ b/ailets-rs/messages_to_markdown/Cargo.toml
@@ -14,5 +14,6 @@ crate-type = ["cdylib", "lib"]
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 areader = { version = "0.1.0", path = "../areader" }
+awriter = { version = "0.1.0", path = "../awriter" }
 getrandom = { version = "0.2", features = ["custom"] }
 scan_json = "1.0.0"

--- a/ailets-rs/messages_to_markdown/src/lib.rs
+++ b/ailets-rs/messages_to_markdown/src/lib.rs
@@ -2,12 +2,12 @@ mod structure_builder;
 
 use areader::AReader;
 use awriter::AWriter;
-use structure_builder::StructureBuilder;
 use scan_json::jiter::Peek;
 use scan_json::RJiter;
 use scan_json::{scan, BoxedAction, ParentParentAndName, StreamOp, Trigger};
 use std::cell::RefCell;
 use std::io::Write;
+use structure_builder::StructureBuilder;
 
 const BUFFER_SIZE: u32 = 1024;
 
@@ -70,6 +70,6 @@ pub fn _messages_to_markdown<W: Write>(mut reader: impl std::io::Read, writer: W
 #[allow(clippy::missing_panics_doc)]
 pub extern "C" fn messages_to_markdown() {
     let reader = AReader::new(c"").unwrap();
-    let writer = AWriter::new(c"");
+    let writer = AWriter::new(c"").unwrap();
     _messages_to_markdown(reader, writer);
 }

--- a/ailets-rs/messages_to_markdown/src/lib.rs
+++ b/ailets-rs/messages_to_markdown/src/lib.rs
@@ -1,6 +1,7 @@
 mod structure_builder;
 
 use areader::AReader;
+use awriter::AWriter;
 use structure_builder::StructureBuilder;
 use scan_json::jiter::Peek;
 use scan_json::RJiter;
@@ -29,7 +30,8 @@ fn on_content_text(
     let mut builder = builder_cell.borrow_mut();
 
     builder.start_paragraph();
-    let wb = rjiter.write_long_str(&mut *builder);
+    let awriter = builder.get_awriter();
+    let wb = rjiter.write_long_str(awriter);
     assert!(wb.is_ok(), "Error on the content item level: {wb:?}");
 
     StreamOp::ValueIsConsumed
@@ -45,7 +47,8 @@ fn on_content_text(
 ///   ```
 #[allow(clippy::missing_panics_doc)]
 pub fn _messages_to_markdown(mut reader: impl std::io::Read) {
-    let builder_cell = RefCell::new(StructureBuilder::new(c""));
+    let awriter = AWriter::new(c"");
+    let builder_cell = RefCell::new(StructureBuilder::new(awriter));
 
     let mut buffer = [0u8; BUFFER_SIZE as usize];
     let rjiter_cell = RefCell::new(RJiter::new(&mut reader, &mut buffer));

--- a/ailets-rs/messages_to_markdown/src/structure_builder.rs
+++ b/ailets-rs/messages_to_markdown/src/structure_builder.rs
@@ -1,15 +1,15 @@
 use actor_runtime::{aclose, awrite, open_write};
 use std::ffi::CStr;
 use std::io::Write;
-pub struct AWriter {
+pub struct StructureBuilder {
     fd: Option<i32>,
     need_para_divider: bool,
 }
 
-impl AWriter {
+impl StructureBuilder {
     pub fn new(filename: &CStr) -> Self {
         let fd = unsafe { open_write(filename.as_ptr()) };
-        AWriter {
+        StructureBuilder {
             fd: Some(fd),
             need_para_divider: false,
         }
@@ -35,7 +35,7 @@ impl AWriter {
     }
 }
 
-impl Drop for AWriter {
+impl Drop for StructureBuilder {
     fn drop(&mut self) {
         if let Some(fd) = self.fd.take() {
             unsafe { aclose(fd) };
@@ -43,7 +43,7 @@ impl Drop for AWriter {
     }
 }
 
-impl std::io::Write for AWriter {
+impl std::io::Write for StructureBuilder {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if let Some(fd) = self.fd {
             let n = unsafe { awrite(fd, buf.as_ptr(), buf.len().try_into().unwrap()) };

--- a/ailets-rs/messages_to_markdown/src/structure_builder.rs
+++ b/ailets-rs/messages_to_markdown/src/structure_builder.rs
@@ -1,22 +1,21 @@
 use std::io::Write;
-use awriter::AWriter;
 
-pub struct StructureBuilder {
-    awriter: AWriter,
+pub struct StructureBuilder<W: Write> {
+    writer: W,
     need_para_divider: bool,
 }
 
-impl StructureBuilder {
-    pub fn new(awriter: AWriter) -> Self {
+impl<W: Write> StructureBuilder<W> {
+    pub fn new(writer: W) -> Self {
         StructureBuilder {
-            awriter,
+            writer,
             need_para_divider: false,
         }
     }
 
     #[must_use]
-    pub fn get_awriter(&mut self) -> &mut AWriter {
-        &mut self.awriter
+    pub fn get_writer(&mut self) -> &mut W {
+        &mut self.writer
     }
 
     pub fn start_paragraph(&mut self) {
@@ -28,7 +27,7 @@ impl StructureBuilder {
 
     pub fn str(&mut self, text: &str) {
         let text_bytes = text.as_bytes();
-        self.awriter.write_all(text_bytes).unwrap();
+        self.writer.write_all(text_bytes).unwrap();
     }
 
     pub fn finish_with_newline(&mut self) {

--- a/ailets-rs/messages_to_markdown/src/structure_builder.rs
+++ b/ailets-rs/messages_to_markdown/src/structure_builder.rs
@@ -1,18 +1,22 @@
-use actor_runtime::{aclose, awrite, open_write};
-use std::ffi::CStr;
 use std::io::Write;
+use awriter::AWriter;
+
 pub struct StructureBuilder {
-    fd: Option<i32>,
+    awriter: AWriter,
     need_para_divider: bool,
 }
 
 impl StructureBuilder {
-    pub fn new(filename: &CStr) -> Self {
-        let fd = unsafe { open_write(filename.as_ptr()) };
+    pub fn new(awriter: AWriter) -> Self {
         StructureBuilder {
-            fd: Some(fd),
+            awriter,
             need_para_divider: false,
         }
+    }
+
+    #[must_use]
+    pub fn get_awriter(&mut self) -> &mut AWriter {
+        &mut self.awriter
     }
 
     pub fn start_paragraph(&mut self) {
@@ -24,7 +28,7 @@ impl StructureBuilder {
 
     pub fn str(&mut self, text: &str) {
         let text_bytes = text.as_bytes();
-        self.write_all(text_bytes).unwrap();
+        self.awriter.write_all(text_bytes).unwrap();
     }
 
     pub fn finish_with_newline(&mut self) {
@@ -32,32 +36,5 @@ impl StructureBuilder {
             self.str("\n");
         }
         self.need_para_divider = false;
-    }
-}
-
-impl Drop for StructureBuilder {
-    fn drop(&mut self) {
-        if let Some(fd) = self.fd.take() {
-            unsafe { aclose(fd) };
-        }
-    }
-}
-
-impl std::io::Write for StructureBuilder {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        if let Some(fd) = self.fd {
-            let n = unsafe { awrite(fd, buf.as_ptr(), buf.len().try_into().unwrap()) };
-            let n: usize = match n {
-                n if n <= 0 => panic!("Failed to write to output stream"),
-                n => n.try_into().unwrap(),
-            };
-            Ok(n)
-        } else {
-            Ok(0)
-        }
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        Ok(())
     }
 }

--- a/ailets-rs/messages_to_markdown/tests/actor.rs
+++ b/ailets-rs/messages_to_markdown/tests/actor.rs
@@ -35,7 +35,10 @@ fn test_multiple_content_items() {
 
     _messages_to_markdown(reader, writer.clone());
 
-    assert_eq!(writer.get_output(), "First item\n\nSecond item\n\nThird item\n");
+    assert_eq!(
+        writer.get_output(),
+        "First item\n\nSecond item\n\nThird item\n"
+    );
 }
 
 #[test]
@@ -59,7 +62,10 @@ fn test_two_messages() {
 
     _messages_to_markdown(reader, writer.clone());
 
-    assert_eq!(writer.get_output(), "First message\n\nSecond message\n\nExtra text\n");
+    assert_eq!(
+        writer.get_output(),
+        "First message\n\nSecond message\n\nExtra text\n"
+    );
 }
 
 #[test]

--- a/ailets-rs/messages_to_markdown/tests/actor.rs
+++ b/ailets-rs/messages_to_markdown/tests/actor.rs
@@ -1,10 +1,9 @@
-use actor_runtime_mocked::{clear_mocks, get_file};
+use actor_runtime_mocked::RcWriter;
 use messages_to_markdown::_messages_to_markdown;
 use std::io::Cursor;
 
 #[test]
 fn test_basic_conversion() {
-    clear_mocks();
     let json_data = r#"
     {
         "role":"assistant",
@@ -13,16 +12,15 @@ fn test_basic_conversion() {
         ]
     }"#;
     let reader = Cursor::new(json_data);
+    let writer = RcWriter::new();
 
-    _messages_to_markdown(reader);
+    _messages_to_markdown(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
-    assert_eq!(result, "Hello!\n");
+    assert_eq!(writer.get_output(), "Hello!\n");
 }
 
 #[test]
 fn test_multiple_content_items() {
-    clear_mocks();
     let json_data = r#"
     {
         "role":"assistant",
@@ -33,16 +31,15 @@ fn test_multiple_content_items() {
         ]
     }"#;
     let reader = Cursor::new(json_data);
+    let writer = RcWriter::new();
 
-    _messages_to_markdown(reader);
+    _messages_to_markdown(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
-    assert_eq!(result, "First item\n\nSecond item\n\nThird item\n");
+    assert_eq!(writer.get_output(), "First item\n\nSecond item\n\nThird item\n");
 }
 
 #[test]
 fn test_two_messages() {
-    clear_mocks();
     let json_data = r#"
     {
         "role":"assistant", 
@@ -58,28 +55,26 @@ fn test_two_messages() {
         ]
     }"#;
     let reader = Cursor::new(json_data);
+    let writer = RcWriter::new();
 
-    _messages_to_markdown(reader);
+    _messages_to_markdown(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
-    assert_eq!(result, "First message\n\nSecond message\n\nExtra text\n");
+    assert_eq!(writer.get_output(), "First message\n\nSecond message\n\nExtra text\n");
 }
 
 #[test]
 fn test_empty_input() {
-    clear_mocks();
     let json_data = "";
     let reader = Cursor::new(json_data);
+    let writer = RcWriter::new();
 
-    _messages_to_markdown(reader);
+    _messages_to_markdown(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
-    assert_eq!(result, "");
+    assert_eq!(writer.get_output(), "");
 }
 
 #[test]
 fn test_long_text() {
-    clear_mocks();
     // Create a 4KB text string
     let long_text = "x".repeat(4096);
     let json_data = format!(
@@ -93,16 +88,15 @@ fn test_long_text() {
         long_text
     );
     let reader = Cursor::new(json_data);
+    let writer = RcWriter::new();
 
-    _messages_to_markdown(reader);
+    _messages_to_markdown(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
-    assert_eq!(result, format!("{}\n", long_text));
+    assert_eq!(writer.get_output(), format!("{}\n", long_text));
 }
 
 #[test]
 fn test_skip_unknown_key_object() {
-    clear_mocks();
     let json_data = r#"
     {
         "role":"assistant", 
@@ -113,16 +107,15 @@ fn test_skip_unknown_key_object() {
         ]
     }"#;
     let reader = Cursor::new(json_data);
+    let writer = RcWriter::new();
 
-    _messages_to_markdown(reader);
+    _messages_to_markdown(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
-    assert_eq!(result, "First message\n\nSecond message\n");
+    assert_eq!(writer.get_output(), "First message\n\nSecond message\n");
 }
 
 #[test]
 fn test_json_escapes() {
-    clear_mocks();
     let json_data = r#"
     {
         "role":"assistant",
@@ -131,9 +124,9 @@ fn test_json_escapes() {
         ]
     }"#;
     let reader = Cursor::new(json_data);
+    let writer = RcWriter::new();
 
-    _messages_to_markdown(reader);
+    _messages_to_markdown(reader, writer.clone());
 
-    let result = String::from_utf8(get_file("").unwrap()).unwrap();
-    assert_eq!(result, "a\n\"\u{0401}\"\n");
+    assert_eq!(writer.get_output(), "a\n\"\u{0401}\"\n");
 }


### PR DESCRIPTION
- Return `Result` instead of panic
- Write tests
- Document the module
- Create `RcWriter` for use in tests
- In actors, introduce `StructureBuilder` to hold AWriter

close #87 