### PR TITLE
A105 expose dag to rust

### DIFF
--- a/ailets-rs/actor_runtime/Cargo.toml
+++ b/ailets-rs/actor_runtime/Cargo.toml
@@ -11,3 +11,7 @@ crate-type = ["cdylib", "lib"]
 [features]
 default = []
 dagops = []
+
+[dependencies]
+base64 = "0.22.1"
+serde_json = "1.0.140"

--- a/ailets-rs/actor_runtime/src/actor_runtime.rs
+++ b/ailets-rs/actor_runtime/src/actor_runtime.rs
@@ -12,21 +12,24 @@ extern "C" {
     /// `dag_value_node` parameters:
     /// - `value_ptr`: pointer to the base64 encoded value
     /// - `explain_ptr`: pointer to the C-string explanation
-    /// return: handle to the value
+    ///
+    /// return: handle to the value, or -1 if error
     #[cfg(feature = "dagops")]
     pub fn dag_value_node(value_ptr: *const u8, explain_ptr: *const c_char) -> c_int;
 
     /// `dag_alias` parameters:
     /// - `alias_ptr`: pointer to the C-string alias
     /// - `node_handle`: handle to the node
-    /// return: handle to the alias
+    ///
+    /// return: handle to the alias, or -1 if error
     #[cfg(feature = "dagops")]
     pub fn dag_alias(alias_ptr: *const c_char, node_handle: c_int) -> c_int;
 
     /// `dag_instantiate_with_deps` parameters:
     /// - `workflow`: pointer to the C-string workflow name
     /// - `deps`: pointer to the C-string JSON dependencies map
-    /// return: handle to the workflow
+    ///
+    /// return: handle to the workflow, or -1 if error
     #[cfg(feature = "dagops")]
     pub fn dag_instantiate_with_deps(workflow: *const c_char, deps: *const c_char) -> c_int;
 }

--- a/ailets-rs/actor_runtime/src/actor_runtime.rs
+++ b/ailets-rs/actor_runtime/src/actor_runtime.rs
@@ -9,13 +9,24 @@ extern "C" {
     pub fn awrite(fd: c_int, buffer_ptr: *const u8, count: c_uint) -> c_int;
     pub fn aclose(fd: c_int) -> c_int;
 
+    /// `dag_value_node` parameters:
+    /// - `value_ptr`: pointer to the base64 encoded value
+    /// - `explain_ptr`: pointer to the C-string explanation
+    /// return: handle to the value
     #[cfg(feature = "dagops")]
     pub fn dag_value_node(value_ptr: *const u8, explain_ptr: *const c_char) -> c_int;
+
+    /// `dag_alias` parameters:
+    /// - `alias_ptr`: pointer to the C-string alias
+    /// - `node_handle`: handle to the node
+    /// return: handle to the alias
     #[cfg(feature = "dagops")]
-    pub fn dag_alias(alias: *const c_char, node_handle: c_int) -> c_int;
+    pub fn dag_alias(alias_ptr: *const c_char, node_handle: c_int) -> c_int;
+
+    /// `dag_instantiate_with_deps` parameters:
+    /// - `workflow`: pointer to the C-string workflow name
+    /// - `deps`: pointer to the C-string JSON dependencies map
+    /// return: handle to the workflow
     #[cfg(feature = "dagops")]
-    pub fn dag_instantiate_with_deps(
-        workflow: *const c_char,
-        deps: *const u8, // later to be replaced with a map using UniFFI
-    ) -> c_int;
+    pub fn dag_instantiate_with_deps(workflow: *const c_char, deps: *const c_char) -> c_int;
 }

--- a/ailets-rs/actor_runtime/src/dagops.rs
+++ b/ailets-rs/actor_runtime/src/dagops.rs
@@ -63,12 +63,13 @@ impl DagOpsTrait for DagOps {
         for (key, value) in deps {
             deps_json.insert(key, serde_json::Value::Number(value.into()));
         }
-        let deps_str = serde_json::to_string(&deps_json).map_err(|e| e.to_string())?;
+        let deps_vec = serde_json::to_vec(&deps_json).map_err(|e| e.to_string())?;
+        let deps_str = std::ffi::CString::new(deps_vec).map_err(|e| e.to_string())?;
 
         let handle = unsafe {
             dag_instantiate_with_deps(
                 workflow_name.as_ptr().cast::<i8>(),
-                deps_str.as_bytes().as_ptr().cast::<i8>(),
+                deps_str.as_ptr().cast::<i8>(),
             )
         };
         u32::try_from(handle).map_err(|_| "dag_instantiate_with_deps: error".to_string())

--- a/ailets-rs/actor_runtime/src/dagops.rs
+++ b/ailets-rs/actor_runtime/src/dagops.rs
@@ -39,7 +39,7 @@ impl DagOpsTrait for DagOps {
 
         let handle =
             unsafe { dag_value_node(value_base64.as_ptr(), explain.as_ptr().cast::<i8>()) };
-        Ok(handle as u32)
+        u32::try_from(handle).map_err(|_| "dag_value_node: error".to_string())
     }
 
     fn alias(&mut self, alias: &str, node_handle: u32) -> Result<u32, String> {
@@ -49,7 +49,7 @@ impl DagOpsTrait for DagOps {
         let node_handle = node_handle as i32;
 
         let handle = unsafe { dag_alias(alias.as_ptr().cast::<i8>(), node_handle) };
-        Ok(handle as u32)
+        u32::try_from(handle).map_err(|_| "dag_alias: error".to_string())
     }
 
     fn instantiate_with_deps(
@@ -71,6 +71,6 @@ impl DagOpsTrait for DagOps {
                 deps_str.as_bytes().as_ptr().cast::<i8>(),
             )
         };
-        Ok(handle as u32)
+        u32::try_from(handle).map_err(|_| "dag_instantiate_with_deps: error".to_string())
     }
 }

--- a/ailets-rs/actor_runtime/src/dagops.rs
+++ b/ailets-rs/actor_runtime/src/dagops.rs
@@ -34,17 +34,20 @@ impl DagOpsTrait for DagOps {
         enc.finish().map_err(|e| e.to_string())?;
         drop(enc);
         value_base64.push(b'\0');
+
+        let explain = std::ffi::CString::new(explain).map_err(|e| e.to_string())?;
+
         let handle =
             unsafe { dag_value_node(value_base64.as_ptr(), explain.as_ptr().cast::<i8>()) };
         Ok(handle as u32)
     }
 
     fn alias(&mut self, alias: &str, node_handle: u32) -> Result<u32, String> {
-        println!("dag_alias: {alias}, node_handle: {node_handle}");
+        let alias = std::ffi::CString::new(alias).map_err(|e| e.to_string())?;
         #[allow(clippy::cast_possible_wrap)]
         let node_handle = node_handle as i32;
-        unsafe { dag_alias(alias.as_ptr().cast::<i8>(), node_handle) };
-        Ok(0)
+        let handle = unsafe { dag_alias(alias.as_ptr().cast::<i8>(), node_handle) };
+        Ok(handle as u32)
     }
 
     fn instantiate_with_deps(

--- a/ailets-rs/run_actor.py
+++ b/ailets-rs/run_actor.py
@@ -147,6 +147,18 @@ class NodeRuntime:
         self.streams[fd] = None
         return 0
 
+    def dag_instantiate_with_deps(self, workflow: str, deps: str) -> int:
+        print(f"python dag_instantiate_with_deps, workflow: {workflow}, deps: {deps}")
+        return 0
+
+    def dag_value_node(self, value: str, explain: str) -> int:
+        print(f"python dag_value_node, value: {value}, explain: {explain}")
+        return 0
+
+    def dag_alias(self, alias: str, node_handle: int) -> int:
+        print(f"python dag_alias, alias: {alias}, node_handle: {node_handle}")
+        return 0
+
 
 class BufToStr:
     def __init__(self) -> None:
@@ -199,6 +211,24 @@ def register_node_runtime(
     def aclose(fd: int) -> int:
         return nr.aclose(fd)
 
+    def dag_instantiate_with_deps(workflow: int, deps: int) -> int:
+        return nr.dag_instantiate_with_deps(
+            buf_to_str.get_string(workflow),
+            buf_to_str.get_string(deps),
+        )
+
+    def dag_value_node(value: int, explain: int) -> int:
+        return nr.dag_value_node(
+            buf_to_str.get_string(value),
+            buf_to_str.get_string(explain),
+        )
+
+    def dag_alias(alias: int, node_handle: int) -> int:
+        return nr.dag_alias(
+            buf_to_str.get_string(alias),
+            node_handle,
+        )
+
     import_object.register(
         "",
         {
@@ -208,6 +238,11 @@ def register_node_runtime(
             "aread": wasmer.Function(store, aread),
             "awrite": wasmer.Function(store, awrite),
             "aclose": wasmer.Function(store, aclose),
+            "dag_instantiate_with_deps": wasmer.Function(
+                store, dag_instantiate_with_deps
+            ),
+            "dag_value_node": wasmer.Function(store, dag_value_node),
+            "dag_alias": wasmer.Function(store, dag_alias),
         },
     )
 

--- a/ailets-rs/run_actor.py
+++ b/ailets-rs/run_actor.py
@@ -3,6 +3,7 @@
 import argparse
 from dataclasses import dataclass
 import io
+import base64
 import sys
 from typing import Literal, Optional, Protocol, Sequence, cast
 import wasmer  # type: ignore[import-untyped]
@@ -152,7 +153,12 @@ class NodeRuntime:
         return 0
 
     def dag_value_node(self, value: str, explain: str) -> int:
-        print(f"python dag_value_node, value: {value}, explain: {explain}")
+        try:
+            value = base64.b64decode(value).decode("utf-8")
+        except Exception as e:
+            print(f"dag_value_node: Error decoding value: {e}")
+            return -1
+        print(f"dag_value_node: value: {value}, explain: {explain}")
         return 0
 
     def dag_alias(self, alias: str, node_handle: int) -> int:

--- a/ailets-rs/run_actor.py
+++ b/ailets-rs/run_actor.py
@@ -149,8 +149,11 @@ class NodeRuntime:
         return 0
 
     def dag_instantiate_with_deps(self, workflow: str, deps: str) -> int:
-        print(f"python dag_instantiate_with_deps, workflow: {workflow}, deps: {deps}")
-        return 0
+        handle = len(workflow)
+        print(
+            f"dag_instantiate_with_deps: workflow: {workflow}, deps: {deps} -> {handle}"
+        )
+        return handle
 
     def dag_value_node(self, value: str, explain: str) -> int:
         try:
@@ -158,12 +161,14 @@ class NodeRuntime:
         except Exception as e:
             print(f"dag_value_node: Error decoding value: {e}")
             return -1
-        print(f"dag_value_node: value: {value}, explain: {explain}")
-        return 0
+        handle = len(value)
+        print(f"dag_value_node: value: {value}, explain: {explain} -> {handle}")
+        return handle
 
     def dag_alias(self, alias: str, node_handle: int) -> int:
-        print(f"python dag_alias, alias: {alias}, node_handle: {node_handle}")
-        return 0
+        handle = len(alias)
+        print(f"dag_alias: alias: {alias}, node_handle: {node_handle} -> {handle}")
+        return handle
 
 
 class BufToStr:

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -219,8 +219,7 @@ async def main() -> None:
 
     if args.model == "gpt4o":
         hijack_msg2md(nodereg)
-        if not len(args.tools):
-            hijack_gpt_resp2msg(nodereg)
+        hijack_gpt_resp2msg(nodereg)
 
     prompt = get_prompt(args.prompt)
 

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -110,6 +110,15 @@ class INodeDagops(Protocol):
     def detach_from_alias(self, alias: str) -> None:
         raise NotImplementedError
 
+    def v2_alias(self, alias: str, node_handle: int) -> int:
+        raise NotImplementedError
+
+    def v2_add_value(self, value: bytes, explain: Optional[str] = None) -> int:
+        raise NotImplementedError
+
+    def v2_instantiate_with_deps(self, target: str, aliases: dict[str, int]) -> int:
+        raise NotImplementedError
+
 
 class INodeRuntime(Protocol):
     def get_name(self) -> str:

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -113,7 +113,7 @@ class INodeDagops(Protocol):
     def v2_alias(self, alias: str, node_handle: int) -> int:
         raise NotImplementedError
 
-    def v2_add_value(self, value: bytes, explain: Optional[str] = None) -> int:
+    def v2_add_value_node(self, value: bytes, explain: Optional[str] = None) -> int:
         raise NotImplementedError
 
     def v2_instantiate_with_deps(self, target: str, aliases: dict[str, int]) -> int:

--- a/pylib-v1/ailets/cons/node_dagops.py
+++ b/pylib-v1/ailets/cons/node_dagops.py
@@ -1,5 +1,5 @@
 import dataclasses
-from typing import Optional
+from typing import List, Optional
 
 from ailets.cons.pipelines import instantiate_with_deps
 
@@ -17,6 +17,7 @@ class NodeDagops(INodeDagops):
         self.streams = env.streams
         self.processes = env.processes
         self.node = node
+        self.handle_to_name: List[str] = []
 
     def add_value_node(self, value: bytes, explain: Optional[str] = None) -> str:
         node = self.dagops.add_value_node(value, self.streams, self.processes, explain)
@@ -38,3 +39,28 @@ class NodeDagops(INodeDagops):
             for i, dep in enumerate(node.deps):
                 if dep.source == alias:
                     node.deps[i] = dataclasses.replace(dep, source=defunc_name)
+
+    def v2_alias(self, alias: str, node_handle: int) -> int:
+        node_name = self.handle_to_name[node_handle]
+
+        self.alias(alias, node_name)
+
+        self.handle_to_name.append(alias)
+        return len(self.handle_to_name) - 1
+
+    def v2_add_value(self, value: bytes, explain: Optional[str] = None) -> int:
+        node_name = self.add_value_node(value, explain)
+
+        self.handle_to_name.append(node_name)
+
+        return len(self.handle_to_name) - 1
+
+    def v2_instantiate_with_deps(self, target: str, aliases: dict[str, int]) -> int:
+        name_aliases = {
+            alias: self.handle_to_name[handle] for alias, handle in aliases.items()
+        }
+
+        node_name = self.instantiate_with_deps(target, name_aliases)
+
+        self.handle_to_name.append(node_name)
+        return len(self.handle_to_name) - 1

--- a/pylib-v1/ailets/cons/node_dagops.py
+++ b/pylib-v1/ailets/cons/node_dagops.py
@@ -48,7 +48,7 @@ class NodeDagops(INodeDagops):
         self.handle_to_name.append(alias)
         return len(self.handle_to_name) - 1
 
-    def v2_add_value(self, value: bytes, explain: Optional[str] = None) -> int:
+    def v2_add_value_node(self, value: bytes, explain: Optional[str] = None) -> int:
         node_name = self.add_value_node(value, explain)
 
         self.handle_to_name.append(node_name)

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -100,16 +100,15 @@ def fill_wasm_import_object(
             return -1
 
     async def dag_value_node(value_ptr: int, explain_ptr: int) -> int:
-        value = buf_to_str.get_string(value_ptr)
-        explain = buf_to_str.get_string(explain_ptr)
+        value_str = buf_to_str.get_string(value_ptr)
+        explain_str = buf_to_str.get_string(explain_ptr)
         try:
-            value = base64.b64decode(value).decode("utf-8")
+            value = base64.b64decode(value_str)
         except Exception as e:
             print(f"value_node: Error decoding value: {e}")
             return -1
 
-        handle = len(value)
-        print(f"value_node: value: {value}, explain: {explain} -> {handle}")
+        handle = runtime.dagops().v2_add_value_node(value, explain_str)
         return handle
 
     async def dag_alias(alias_ptr: int, node_handle: int) -> int:

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -113,8 +113,7 @@ def fill_wasm_import_object(
 
     async def dag_alias(alias_ptr: int, node_handle: int) -> int:
         alias = buf_to_str.get_string(alias_ptr)
-        handle = len(alias)
-        print(f"alias: alias: {alias}, node_handle: {node_handle} -> {handle}")
+        handle = runtime.dagops().v2_alias(alias, node_handle)
         return handle
 
     def sync_n_of_streams(name_ptr: int) -> int:

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -2,6 +2,7 @@ import wasmer  # type: ignore[import-untyped]
 import base64
 import asyncio
 import json
+import sys
 from pydantic import BaseModel
 from typing import Dict
 
@@ -74,7 +75,10 @@ def fill_wasm_import_object(
         try:
             deps_dict = json.loads(deps)
         except Exception as e:
-            print(f"instantiate_with_deps: Error parsing '{workflow}'s input deps: {e}")
+            print(
+                f"instantiate_with_deps: Error parsing '{workflow}'s input deps: {e}",
+                file=sys.stderr,
+            )
             return -1
 
         try:
@@ -85,7 +89,9 @@ def fill_wasm_import_object(
             validated_deps = DepsModel(deps=deps_dict).deps
         except Exception as e:
             print(
-                f"instantiate_with_deps: Error validating '{workflow}'s input deps: {e}"
+                f"instantiate_with_deps: Error validating '{workflow}'s input deps: "
+                f"{e}",
+                file=sys.stderr,
             )
             return -1
 
@@ -95,7 +101,8 @@ def fill_wasm_import_object(
         except Exception as e:
             print(
                 f"instantiate_with_deps: Error instantiating workflow {workflow} "
-                f"with deps {validated_deps}: {e}"
+                f"with deps {validated_deps}: {e}",
+                file=sys.stderr,
             )
             return -1
 
@@ -105,16 +112,33 @@ def fill_wasm_import_object(
         try:
             value = base64.b64decode(value_str)
         except Exception as e:
-            print(f"value_node: Error decoding value: {e}")
+            print(
+                f"value_node: Error decoding value for '{explain_str}': {e}",
+                file=sys.stderr,
+            )
             return -1
 
-        handle = runtime.dagops().v2_add_value_node(value, explain_str)
-        return handle
+        try:
+            handle = runtime.dagops().v2_add_value_node(value, explain_str)
+            return handle
+        except Exception as e:
+            print(
+                f"value_node: Error adding value node for '{explain_str}': {e}",
+                file=sys.stderr,
+            )
+            return -1
 
     async def dag_alias(alias_ptr: int, node_handle: int) -> int:
         alias = buf_to_str.get_string(alias_ptr)
-        handle = runtime.dagops().v2_alias(alias, node_handle)
-        return handle
+        try:
+            handle = runtime.dagops().v2_alias(alias, node_handle)
+            return handle
+        except Exception as e:
+            print(
+                f"alias: Error adding alias '{alias}' to node {node_handle}: {e}",
+                file=sys.stderr,
+            )
+            return -1
 
     def sync_n_of_streams(name_ptr: int) -> int:
         return asyncio.run(n_of_streams(name_ptr))


### PR DESCRIPTION
- Dummy dag functions in the run_actor.py
- Pass names as CString, values as base64, dict as json
- In the cmdline tool, always use the Rust actor
- New version of dag manipulation, with node handles instead of names
- Verbose error handling in dag wrappers
- Need to fix some dag manipulation errors from the actor

close #105 