### PR TITLE
A116 start m2q with text support

### DIFF
--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -516,7 +516,9 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "scan_json"
-version = "1.0.2"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db0bc8dbac31374db3b7f29b0427239df9eafc5464a24ad8d2928cb78e05014"
 dependencies = [
  "rjiter",
 ]

--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -239,7 +239,9 @@ dependencies = [
  "actor_io",
  "actor_runtime",
  "actor_runtime_mocked",
+ "hamcrest",
  "scan_json",
+ "serde_json",
 ]
 
 [[package]]

--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -516,9 +516,7 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "scan_json"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db0bc8dbac31374db3b7f29b0427239df9eafc5464a24ad8d2928cb78e05014"
+version = "1.0.2"
 dependencies = [
  "rjiter",
 ]

--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -239,6 +239,7 @@ dependencies = [
  "actor_io",
  "actor_runtime",
  "actor_runtime_mocked",
+ "getrandom",
  "hamcrest",
  "scan_json",
  "serde_json",

--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -233,6 +233,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "messages_to_query"
+version = "0.1.0"
+dependencies = [
+ "actor_io",
+ "actor_runtime",
+ "actor_runtime_mocked",
+ "scan_json",
+]
+
+[[package]]
 name = "num"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/ailets-rs/Cargo.toml
+++ b/ailets-rs/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "actor_io", "actor_runtime", "actor_runtime_mocked", "cat", "gpt", "messages_to_markdown" ]
+members = [ "actor_io", "actor_runtime", "actor_runtime_mocked", "cat", "gpt", "messages_to_query", "messages_to_markdown" ]
 resolver = "2"
 
 [workspace.package]

--- a/ailets-rs/Cargo.toml
+++ b/ailets-rs/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 authors = ["Oleg Parashchenko <olpa@uucode.com>"]
 license = "MIT"
 
-[patch.crates-io]
-scan_json = { path = "../../streaming_json/scan_json" }
+#[patch.crates-io]
+#scan_json = { path = "../../streaming_json/scan_json" }

--- a/ailets-rs/Cargo.toml
+++ b/ailets-rs/Cargo.toml
@@ -7,3 +7,6 @@ version = "0.1.0"
 edition = "2021"
 authors = ["Oleg Parashchenko <olpa@uucode.com>"]
 license = "MIT"
+
+[patch.crates-io]
+scan_json = { path = "../../streaming_json/scan_json" }

--- a/ailets-rs/build.sh
+++ b/ailets-rs/build.sh
@@ -3,7 +3,7 @@
 DEPLOY_ENV=debug  # or "release"
 
 # Build each crate for wasm
-for crate in cat gpt messages_to_markdown; do
+for crate in cat gpt messages_to_markdown messages_to_query; do
     echo "Building $crate for wasm..."
     cd $crate
     if [ "$DEPLOY_ENV" = "release" ]; then

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 actor_io = { version = "0.1.0", path = "../actor_io" }
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
-scan_json = "1.0.1"
+scan_json = "1.0.2-dev"
 serde_json = "1.0.140"
 
 [dev-dependencies]

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "messages_to_query"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[lib]
+# To run tests, two types are needed
+crate-type = ["cdylib", "lib"]
+# crate-type = ["cdylib"]
+
+[dependencies]
+actor_io = { version = "0.1.0", path = "../actor_io" }
+actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
+actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
+scan_json = "1.0.1"

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -15,3 +15,7 @@ actor_io = { version = "0.1.0", path = "../actor_io" }
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 scan_json = "1.0.1"
+serde_json = "1.0.140"
+
+[dev-dependencies]
+hamcrest = "0.1.5"

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -16,6 +16,7 @@ actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 scan_json = "1.0.1"
 serde_json = "1.0.140"
+getrandom = { version = "0.2", features = ["custom"] }
 
 [dev-dependencies]
 hamcrest = "0.1.5"

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 actor_io = { version = "0.1.0", path = "../actor_io" }
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
-scan_json = "1.0.2-dev"
+scan_json = "1.0.1"
 serde_json = "1.0.140"
 
 [dev-dependencies]

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -9,8 +9,8 @@ pub fn on_message_begin<W: Write>(
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
     let mut builder = builder_cell.borrow_mut();
-    if let Err(e) = builder.start_message() {
-        return StreamOp::Error(Box::new(e));
+    if let Err(e) = builder.begin_message() {
+        return StreamOp::Error(e.into());
     }
     StreamOp::None
 }
@@ -37,7 +37,7 @@ pub fn on_role<W: Write>(
         }
     };
     if let Err(e) = builder_cell.borrow_mut().add_role(role) {
-        return StreamOp::Error(Box::new(e));
+        return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed
 }

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -1,0 +1,28 @@
+use scan_json::{rjiter::jiter::Peek, RJiter, StreamOp};
+use std::cell::RefCell;
+use std::io::Write;
+
+pub fn on_role<W: Write>(rjiter_cell: &RefCell<RJiter>, writer_cell: &RefCell<W>) -> StreamOp {
+    let mut rjiter = rjiter_cell.borrow_mut();
+    let peeked = match rjiter.peek() {
+        Ok(p) => p,
+        Err(e) => return StreamOp::Error(Box::new(e)),
+    };
+    if peeked != Peek::String {
+        let error: Box<dyn std::error::Error> =
+            format!("Expected string for 'role' value, got {peeked:?}").into();
+        return StreamOp::Error(error);
+    }
+
+    let mut writer = writer_cell.borrow_mut();
+    if let Err(e) = writer.write_all(b"\"role\":\"") {
+        return StreamOp::Error(Box::new(e));
+    }
+    if let Err(e) = rjiter.write_long_bytes(&mut *writer) {
+        return StreamOp::Error(Box::new(e));
+    }
+    if let Err(e) = writer.write_all(b"\"\n") {
+        return StreamOp::Error(Box::new(e));
+    }
+    StreamOp::ValueIsConsumed
+}

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -1,27 +1,20 @@
-use scan_json::{rjiter::jiter::Peek, RJiter, StreamOp};
+use scan_json::StreamOp;
+use crate::structure_builder::StructureBuilder;
 use std::cell::RefCell;
 use std::io::Write;
+use scan_json::RJiter;
 
-pub fn on_role<W: Write>(rjiter_cell: &RefCell<RJiter>, writer_cell: &RefCell<W>) -> StreamOp {
+pub fn on_role<W: Write>(rjiter_cell: &RefCell<RJiter>, builder_cell: &RefCell<StructureBuilder<W>>) -> StreamOp {
     let mut rjiter = rjiter_cell.borrow_mut();
-    let peeked = match rjiter.peek() {
-        Ok(p) => p,
-        Err(e) => return StreamOp::Error(Box::new(e)),
+    let role = match rjiter.next_str() {
+        Ok(r) => r,
+        Err(e) => {
+            return StreamOp::Error(
+                format!("Error getting role value. Expected string, got: {e:?}").into(),
+            )
+        }
     };
-    if peeked != Peek::String {
-        let error: Box<dyn std::error::Error> =
-            format!("Expected string for 'role' value, got {peeked:?}").into();
-        return StreamOp::Error(error);
-    }
-
-    let mut writer = writer_cell.borrow_mut();
-    if let Err(e) = writer.write_all(b"\"role\":\"") {
-        return StreamOp::Error(Box::new(e));
-    }
-    if let Err(e) = rjiter.write_long_bytes(&mut *writer) {
-        return StreamOp::Error(Box::new(e));
-    }
-    if let Err(e) = writer.write_all(b"\"\n") {
+    if let Err(e) = builder_cell.borrow_mut().add_role(role) {
         return StreamOp::Error(Box::new(e));
     }
     StreamOp::ValueIsConsumed

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -41,3 +41,81 @@ pub fn on_role<W: Write>(
     }
     StreamOp::ValueIsConsumed
 }
+pub fn on_content_begin<W: Write>(
+    _rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut builder = builder_cell.borrow_mut();
+    if let Err(e) = builder.begin_content() {
+        return StreamOp::Error(e.into());
+    }
+    StreamOp::None
+}
+
+pub fn on_content_end<W: Write>(
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut builder = builder_cell.borrow_mut();
+    builder.end_content()?;
+    Ok(())
+}
+
+pub fn on_content_item_begin<W: Write>(
+    _rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut builder = builder_cell.borrow_mut();
+    if let Err(e) = builder.begin_content_item() {
+        return StreamOp::Error(e.into());
+    }
+    StreamOp::None
+}
+
+pub fn on_content_item_end<W: Write>(
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut builder = builder_cell.borrow_mut();
+    builder.end_content_item()?;
+    Ok(())
+}
+
+pub fn on_content_item_type<W: Write>(
+    rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut rjiter = rjiter_cell.borrow_mut();
+    let item_type = match rjiter.next_str() {
+        Ok(t) => t,
+        Err(e) => {
+            return StreamOp::Error(
+                format!("Error getting type value. Expected string, got: {e:?}").into(),
+            )
+        }
+    };
+    if let Err(e) = builder_cell
+        .borrow_mut()
+        .add_item_type(item_type.to_string())
+    {
+        return StreamOp::Error(e.into());
+    }
+    StreamOp::ValueIsConsumed
+}
+
+pub fn on_content_text<W: Write>(
+    rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut rjiter = rjiter_cell.borrow_mut();
+    let text = match rjiter.next_str() {
+        Ok(t) => t,
+        Err(e) => {
+            return StreamOp::Error(
+                format!("Error getting text value. Expected string, got: {e:?}").into(),
+            )
+        }
+    };
+    if let Err(e) = builder_cell.borrow_mut().add_text(text) {
+        return StreamOp::Error(e.into());
+    }
+    StreamOp::ValueIsConsumed
+}

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -1,10 +1,32 @@
-use scan_json::StreamOp;
 use crate::structure_builder::StructureBuilder;
+use scan_json::RJiter;
+use scan_json::StreamOp;
 use std::cell::RefCell;
 use std::io::Write;
-use scan_json::RJiter;
 
-pub fn on_role<W: Write>(rjiter_cell: &RefCell<RJiter>, builder_cell: &RefCell<StructureBuilder<W>>) -> StreamOp {
+pub fn on_message_begin<W: Write>(
+    _rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut builder = builder_cell.borrow_mut();
+    if let Err(e) = builder.start_message() {
+        return StreamOp::Error(Box::new(e));
+    }
+    StreamOp::None
+}
+
+pub fn on_message_end<W: Write>(
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut builder = builder_cell.borrow_mut();
+    builder.end_message()?;
+    Ok(())
+}
+
+pub fn on_role<W: Write>(
+    rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
     let mut rjiter = rjiter_cell.borrow_mut();
     let role = match rjiter.next_str() {
         Ok(r) => r,

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -1,3 +1,6 @@
+mod handlers;
+pub mod structure_builder;
+
 use actor_io::{AReader, AWriter};
 use actor_runtime::err_to_heap_c_string;
 use scan_json::RJiter;
@@ -6,48 +9,49 @@ use scan_json::{scan, BoxedAction, BoxedEndAction, ParentAndName, Trigger};
 use std::cell::RefCell;
 use std::ffi::c_char;
 use std::io::Write;
-
-mod handlers;
-pub mod structure_builder;
+use structure_builder::StructureBuilder;
 
 const BUFFER_SIZE: u32 = 1024;
 
 fn on_message_begin<W: Write>(
     _rjiter_cell: &RefCell<RJiter>,
-    writer_cell: &RefCell<W>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
-    let mut writer = writer_cell.borrow_mut();
-    writer.write_all(b"{").unwrap();
+    let mut builder = builder_cell.borrow_mut();
+    builder.start_message().unwrap();
     StreamOp::None
 }
 
-fn on_message_end<W: Write>(writer_cell: &RefCell<W>) -> Result<(), Box<dyn std::error::Error>> {
-    let mut writer = writer_cell.borrow_mut();
-    writer.write_all(b"}\n").unwrap();
+fn on_message_end<W: Write>(builder_cell: &RefCell<StructureBuilder<W>>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut builder = builder_cell.borrow_mut();
+    builder.end_message().unwrap();
     Ok(())
 }
 
+/// # Errors
+/// If anything goes wrong.
 pub fn _process_query<W: Write>(
     mut reader: impl std::io::Read,
     writer: W,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut buffer = vec![0u8; BUFFER_SIZE as usize];
     let rjiter_cell = RefCell::new(RJiter::new(&mut reader, &mut buffer));
-    let builder_cell = RefCell::new(writer);
+    let builder = StructureBuilder::new(writer);
+    let builder_cell = RefCell::new(builder);
 
     let message_begin = Trigger::new(
         Box::new(ParentAndName::new(
             "#top".to_string(),
             "#object".to_string(),
         )),
-        Box::new(on_message_begin) as BoxedAction<'_, W>,
+        Box::new(on_message_begin) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let message_end = Trigger::new(
         Box::new(ParentAndName::new(
             "#top".to_string(),
             "#object".to_string(),
         )),
-        Box::new(on_message_end) as BoxedEndAction<'_, W>,
+        Box::new(on_message_end) as BoxedEndAction<'_, StructureBuilder<W>>,
     );
 
     scan(

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -38,13 +38,11 @@ pub fn _process_query<W: Write>(
         Box::new(handlers::on_message_end) as BoxedEndAction<'_, StructureBuilder<W>>,
     );
     let role = Trigger::new(
-        Box::new(ParentAndName::new(
-            "#object".to_string(),
-            "role".to_string(),
-        )),
+        Box::new(ParentAndName::new("#top".to_string(), "role".to_string())),
         Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
     );
 
+    builder_cell.borrow_mut().get_writer().write_all(b"[")?;
     scan(
         &[message_begin, role],
         &[message_end],
@@ -52,6 +50,7 @@ pub fn _process_query<W: Write>(
         &rjiter_cell,
         &builder_cell,
     )?;
+    builder_cell.borrow_mut().get_writer().write_all(b"]")?;
     Ok(())
 }
 

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -20,7 +20,7 @@ fn on_message_begin<W: Write>(
 
 fn on_message_end<W: Write>(writer_cell: &RefCell<W>) -> Result<(), Box<dyn std::error::Error>> {
     let mut writer = writer_cell.borrow_mut();
-    writer.write_all(b"}").unwrap();
+    writer.write_all(b"}\n").unwrap();
     Ok(())
 }
 

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -12,17 +12,51 @@ use structure_builder::StructureBuilder;
 
 const BUFFER_SIZE: u32 = 1024;
 
-/// # Errors
-/// If anything goes wrong.
-pub fn _process_query<W: Write>(
-    mut reader: impl std::io::Read,
-    writer: W,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let mut buffer = vec![0u8; BUFFER_SIZE as usize];
-    let rjiter_cell = RefCell::new(RJiter::new(&mut reader, &mut buffer));
-    let builder = StructureBuilder::new(writer);
-    let builder_cell = RefCell::new(builder);
-
+fn create_begin_triggers<'a, W: Write + 'a>(
+) -> Vec<Trigger<'a, BoxedAction<'a, StructureBuilder<W>>>> {
+    let content_text = Trigger::new(
+        Box::new(ParentAndName::new("#array".to_string(), "text".to_string())),
+        Box::new(handlers::on_content_text) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_item_begin = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "content".to_string(),
+            "#array".to_string(),
+            "#object".to_string(),
+        )),
+        Box::new(handlers::on_content_item_begin) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_item_type = Trigger::new(
+        Box::new(ParentAndName::new("#array".to_string(), "type".to_string())),
+        Box::new(handlers::on_content_item_type) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_begin_arr = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "#top".to_string(),
+            "#array".to_string(),
+            "content".to_string(),
+        )),
+        Box::new(handlers::on_content_begin) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_begin_jsonl = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#top".to_string(),
+            "content".to_string(),
+        )),
+        Box::new(handlers::on_content_begin) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let role_arr = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "#top".to_string(),
+            "#array".to_string(),
+            "role".to_string(),
+        )),
+        Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let role_jsonl = Trigger::new(
+        Box::new(ParentAndName::new("#top".to_string(), "role".to_string())),
+        Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
+    );
     let message_begin_arr = Trigger::new(
         Box::new(ParentParentAndName::new(
             "#top".to_string(),
@@ -38,6 +72,22 @@ pub fn _process_query<W: Write>(
         )),
         Box::new(handlers::on_message_begin) as BoxedAction<'_, StructureBuilder<W>>,
     );
+
+    vec![
+        content_text,
+        content_item_begin,
+        content_item_type,
+        content_begin_arr,
+        content_begin_jsonl,
+        role_arr,
+        role_jsonl,
+        message_begin_arr,
+        message_begin_jsonl,
+    ]
+}
+
+fn create_end_triggers<'a, W: Write + 'a>(
+) -> Vec<Trigger<'a, BoxedEndAction<'a, StructureBuilder<W>>>> {
     let message_end_arr = Trigger::new(
         Box::new(ParentParentAndName::new(
             "#top".to_string(),
@@ -53,26 +103,6 @@ pub fn _process_query<W: Write>(
         )),
         Box::new(handlers::on_message_end) as BoxedEndAction<'_, StructureBuilder<W>>,
     );
-    let role_arr = Trigger::new(
-        Box::new(ParentParentAndName::new(
-            "#top".to_string(),
-            "#array".to_string(),
-            "role".to_string(),
-        )),
-        Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
-    );
-    let role_jsonl = Trigger::new(
-        Box::new(ParentAndName::new("#top".to_string(), "role".to_string())),
-        Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
-    );
-    let content_begin_arr = Trigger::new(
-        Box::new(ParentParentAndName::new(
-            "#top".to_string(),
-            "#array".to_string(),
-            "content".to_string(),
-        )),
-        Box::new(handlers::on_content_begin) as BoxedAction<'_, StructureBuilder<W>>,
-    );
     let content_end_arr = Trigger::new(
         Box::new(ParentParentAndName::new(
             "#top".to_string(),
@@ -81,27 +111,12 @@ pub fn _process_query<W: Write>(
         )),
         Box::new(handlers::on_content_end) as BoxedEndAction<'_, StructureBuilder<W>>,
     );
-    let content_begin_jsonl = Trigger::new(
-        Box::new(ParentAndName::new(
-            "#top".to_string(),
-            "content".to_string(),
-        )),
-        Box::new(handlers::on_content_begin) as BoxedAction<'_, StructureBuilder<W>>,
-    );
     let content_end_jsonl = Trigger::new(
         Box::new(ParentAndName::new(
             "#top".to_string(),
             "content".to_string(),
         )),
         Box::new(handlers::on_content_end) as BoxedEndAction<'_, StructureBuilder<W>>,
-    );
-    let content_item_begin = Trigger::new(
-        Box::new(ParentParentAndName::new(
-            "content".to_string(),
-            "#array".to_string(),
-            "#object".to_string(),
-        )),
-        Box::new(handlers::on_content_item_begin) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let content_item_end = Trigger::new(
         Box::new(ParentParentAndName::new(
@@ -111,34 +126,33 @@ pub fn _process_query<W: Write>(
         )),
         Box::new(handlers::on_content_item_end) as BoxedEndAction<'_, StructureBuilder<W>>,
     );
-    let content_item_type = Trigger::new(
-        Box::new(ParentAndName::new("#array".to_string(), "type".to_string())),
-        Box::new(handlers::on_content_item_type) as BoxedAction<'_, StructureBuilder<W>>,
-    );
-    let content_text = Trigger::new(
-        Box::new(ParentAndName::new("#array".to_string(), "text".to_string())),
-        Box::new(handlers::on_content_text) as BoxedAction<'_, StructureBuilder<W>>,
-    );
+
+    vec![
+        content_item_end,
+        content_end_arr,
+        content_end_jsonl,
+        message_end_arr,
+        message_end_jsonl,
+    ]
+}
+
+/// # Errors
+/// If anything goes wrong.
+pub fn _process_query<W: Write>(
+    mut reader: impl std::io::Read,
+    writer: W,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut buffer = vec![0u8; BUFFER_SIZE as usize];
+    let rjiter_cell = RefCell::new(RJiter::new(&mut reader, &mut buffer));
+    let builder = StructureBuilder::new(writer);
+    let builder_cell = RefCell::new(builder);
+
+    let begin_triggers = create_begin_triggers();
+    let end_triggers = create_end_triggers();
 
     scan(
-        &[
-            content_text,
-            content_item_begin,
-            content_item_type,
-            content_begin_arr,
-            content_begin_jsonl,
-            role_arr,
-            role_jsonl,
-            message_begin_arr,
-            message_begin_jsonl,
-        ],
-        &[
-            content_item_end,
-            content_end_arr,
-            content_end_jsonl,
-            message_end_arr,
-            message_end_jsonl,
-        ],
+        &begin_triggers,
+        &end_triggers,
         &[],
         &rjiter_cell,
         &builder_cell,

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -41,11 +41,35 @@ pub fn _process_query<W: Write>(
         Box::new(ParentAndName::new("#top".to_string(), "role".to_string())),
         Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
     );
+    let content_begin = Trigger::new(
+        Box::new(ParentAndName::new("#top".to_string(), "content".to_string())),
+        Box::new(handlers::on_content_begin) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_end = Trigger::new(
+        Box::new(ParentAndName::new("#top".to_string(), "content".to_string())),
+        Box::new(handlers::on_content_end) as BoxedEndAction<'_, StructureBuilder<W>>,
+    );
+    let content_item_begin = Trigger::new(
+        Box::new(ParentAndName::new("content".to_string(), "#array".to_string())),
+        Box::new(handlers::on_content_item_begin) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_item_end = Trigger::new(
+        Box::new(ParentAndName::new("content".to_string(), "#array".to_string())),
+        Box::new(handlers::on_content_item_end) as BoxedEndAction<'_, StructureBuilder<W>>,
+    );
+    let content_item_type = Trigger::new(
+        Box::new(ParentAndName::new("#array".to_string(), "type".to_string())),
+        Box::new(handlers::on_content_item_type) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_text = Trigger::new(
+        Box::new(ParentAndName::new("#array".to_string(), "text".to_string())),
+        Box::new(handlers::on_content_text) as BoxedAction<'_, StructureBuilder<W>>,
+    );
 
     builder_cell.borrow_mut().get_writer().write_all(b"[")?;
     scan(
-        &[message_begin, role],
-        &[message_end],
+        &[message_begin, role, content_begin, content_item_begin, content_item_type, content_text],
+        &[message_end, content_end, content_item_end],
         &[],
         &rjiter_cell,
         &builder_cell,

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -23,32 +23,72 @@ pub fn _process_query<W: Write>(
     let builder = StructureBuilder::new(writer);
     let builder_cell = RefCell::new(builder);
 
-    let message_begin = Trigger::new(
+    let message_begin_arr = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "#top".to_string(),
+            "#array".to_string(),
+            "#object".to_string(),
+        )),
+        Box::new(handlers::on_message_begin) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let message_begin_jsonl = Trigger::new(
         Box::new(ParentAndName::new(
             "#top".to_string(),
             "#object".to_string(),
         )),
         Box::new(handlers::on_message_begin) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let message_end = Trigger::new(
+    let message_end_arr = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "#top".to_string(),
+            "#array".to_string(),
+            "#object".to_string(),
+        )),
+        Box::new(handlers::on_message_end) as BoxedEndAction<'_, StructureBuilder<W>>,
+    );
+    let message_end_jsonl = Trigger::new(
         Box::new(ParentAndName::new(
             "#top".to_string(),
             "#object".to_string(),
         )),
         Box::new(handlers::on_message_end) as BoxedEndAction<'_, StructureBuilder<W>>,
     );
-    let role = Trigger::new(
+    let role_arr = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "#top".to_string(),
+            "#array".to_string(),
+            "role".to_string(),
+        )),
+        Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let role_jsonl = Trigger::new(
         Box::new(ParentAndName::new("#top".to_string(), "role".to_string())),
         Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_begin = Trigger::new(
+    let content_begin_arr = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "#top".to_string(),
+            "#array".to_string(),
+            "content".to_string(),
+        )),
+        Box::new(handlers::on_content_begin) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let content_end_arr = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "#top".to_string(),
+            "#array".to_string(),
+            "content".to_string(),
+        )),
+        Box::new(handlers::on_content_end) as BoxedEndAction<'_, StructureBuilder<W>>,
+    );
+    let content_begin_jsonl = Trigger::new(
         Box::new(ParentAndName::new(
             "#top".to_string(),
             "content".to_string(),
         )),
         Box::new(handlers::on_content_begin) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_end = Trigger::new(
+    let content_end_jsonl = Trigger::new(
         Box::new(ParentAndName::new(
             "#top".to_string(),
             "content".to_string(),
@@ -82,14 +122,23 @@ pub fn _process_query<W: Write>(
 
     scan(
         &[
-            message_begin,
-            role,
-            content_begin,
+            content_text,
             content_item_begin,
             content_item_type,
-            content_text,
+            content_begin_arr,
+            content_begin_jsonl,
+            role_arr,
+            role_jsonl,
+            message_begin_arr,
+            message_begin_jsonl,
         ],
-        &[message_end, content_end, content_item_end],
+        &[
+            content_item_end,
+            content_end_arr,
+            content_end_jsonl,
+            message_end_arr,
+            message_end_jsonl,
+        ],
         &[],
         &rjiter_cell,
         &builder_cell,

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -1,3 +1,62 @@
-fn main() {
-    println!("Hello, world!");
+use scan_json::{scan, BoxedAction, BoxedEndAction, ContextFrame, Name, ParentAndName, Trigger};
+use std::io::Write;
+use std::cell::RefCell;
+use scan_json::StreamOp;
+use scan_json::RJiter;
+
+fn on_message_begin(rjiter_cell: &RefCell<RJiter>, writer_cell: &RefCell<dyn Write>) -> StreamOp {
+    let writer = writer_cell.borrow_mut();
+    writer.write_all(b"{").unwrap();
+    StreamOp::Continue
 }
+
+fn on_message_end(rjiter_cell: &RefCell<RJiter>, writer_cell: &RefCell<dyn Write>) -> StreamOp {
+    let writer = writer_cell.borrow_mut();
+    writer.write_all(b"}").unwrap();
+    StreamOp::Continue
+}
+
+pub fn _process_query<W: Write>(
+    mut reader: impl std::io::Read,
+    writer: W,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut rjiter_cell = RefCell::new(RJiter::new(&mut reader, &mut buffer));
+    let mut builder_cell = RefCell::new(QueryBuilder::new(writer));
+
+    let message_begin = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#top".to_string(),
+            "#object".to_string(),
+        )),
+        Box::new(on_message_begin) as BA<'_, W>,
+    );
+    let message_end = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#top".to_string(),
+            "#object".to_string(),
+        )),
+        Box::new(on_message_end) as BA<'_, W>,
+    );
+
+    scan(&[message_begin], &[message_end], &[], &rjiter_cell, &builder_cell)?;
+    Ok(())
+}
+
+/// # Panics
+/// If anything goes wrong.
+#[no_mangle]
+pub extern "C" fn process_query() -> *const c_char {
+    let reader = match AReader::new(c"") {
+        Ok(reader) => reader,
+        Err(e) => return err_to_heap_c_string(&format!("Failed to create reader: {e:?}")),
+    };
+    let writer = match AWriter::new(c"") {
+        Ok(writer) => writer,
+        Err(e) => return err_to_heap_c_string(&format!("Failed to create writer: {e:?}")),
+    };
+    if let Err(e) = _process_query(reader, writer) {
+        return err_to_heap_c_string(&format!("Failed to process query: {e}"));
+    }
+    std::ptr::null()
+}
+

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -80,7 +80,6 @@ pub fn _process_query<W: Write>(
         Box::new(handlers::on_content_text) as BoxedAction<'_, StructureBuilder<W>>,
     );
 
-    builder_cell.borrow_mut().get_writer().write_all(b"[")?;
     scan(
         &[
             message_begin,
@@ -95,7 +94,7 @@ pub fn _process_query<W: Write>(
         &rjiter_cell,
         &builder_cell,
     )?;
-    builder_cell.borrow_mut().get_writer().write_all(b"]")?;
+    builder_cell.borrow_mut().end()?;
     Ok(())
 }
 

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -7,6 +7,9 @@ use std::cell::RefCell;
 use std::ffi::c_char;
 use std::io::Write;
 
+mod handlers;
+pub mod structure_builder;
+
 const BUFFER_SIZE: u32 = 1024;
 
 fn on_message_begin<W: Write>(

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -14,41 +14,57 @@ impl<W: Write> StructureBuilder<W> {
         &mut self.writer
     }
 
+    /// # Errors
+    /// I/O
     pub fn start_message(&mut self) -> std::io::Result<()> {
         self.writer.write_all(b"{")?;
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn add_role(&mut self, role: &str) -> std::io::Result<()> {
-        write!(self.writer, r#""role":"{}""#, role)?;
+        write!(self.writer, r#""role":"{role}""#)?;
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn start_content(&mut self) -> std::io::Result<()> {
         self.writer.write_all(br#","content":["#)?;
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn start_text_item(&mut self) -> std::io::Result<()> {
         self.writer.write_all(br#"{"type":"text""#)?;
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn add_text(&mut self, text: &str) -> std::io::Result<()> {
-        write!(self.writer, r#","text":"{}""#, text)?;
+        write!(self.writer, r#","text":"{text}""#)?;
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn end_text_item(&mut self) -> std::io::Result<()> {
         self.writer.write_all(b"}")?;
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn end_content(&mut self) -> std::io::Result<()> {
         self.writer.write_all(b"]")?;
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn end_message(&mut self) -> std::io::Result<()> {
         self.writer.write_all(b"}")?;
         Ok(())

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -18,7 +18,7 @@ fn is_write_started(progress: &Progress) -> bool {
 const PRELUDE: &str = r#"{ "url": "https://api.openai.com/v1/chat/completions",
 "method": "POST",
 "headers": { "Content-type": "application/json", "Authorization": "Bearer {{secret('openai','gpt4o')}}" },
-"body": { "model": "gpt-4o", "messages": ["#;
+"body": { "model": "gpt-4o-mini", "stream": true, "messages": ["#;
 
 pub struct StructureBuilder<W: Write> {
     writer: W,

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -157,17 +157,8 @@ impl<W: Write> StructureBuilder<W> {
     }
 
     fn write_item_prologue(&mut self, item_type: &str) -> Result<(), String> {
-        self.writer
-            .write_all(br#"{"type":""#)
+        write!(self.writer, r#"{{"type":"{item_type}","{item_type}":"#)
             .map_err(|e| e.to_string())?;
-        self.writer
-            .write_all(item_type.as_bytes())
-            .map_err(|e| e.to_string())?;
-        self.writer.write_all(b"\",\"").map_err(|e| e.to_string())?;
-        self.writer
-            .write_all(item_type.as_bytes())
-            .map_err(|e| e.to_string())?;
-        self.writer.write_all(b"\":").map_err(|e| e.to_string())?;
         Ok(())
     }
 
@@ -179,11 +170,7 @@ impl<W: Write> StructureBuilder<W> {
         }
         self.really_begin_content_item()?;
         self.write_item_prologue("text")?;
-        self.writer.write_all(b"\"").map_err(|e| e.to_string())?;
-        self.writer
-            .write_all(text.as_bytes())
-            .map_err(|e| e.to_string())?;
-        self.writer.write_all(b"\"").map_err(|e| e.to_string())?;
+        write!(self.writer, r#""{text}""#).map_err(|e| e.to_string())?;
         self.content_item = Progress::ChildIsWritten;
         Ok(())
     }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -13,4 +13,44 @@ impl<W: Write> StructureBuilder<W> {
     pub fn get_writer(&mut self) -> &mut W {
         &mut self.writer
     }
+
+    pub fn start_message(&mut self) -> std::io::Result<()> {
+        self.writer.write_all(b"{")?;
+        Ok(())
+    }
+
+    pub fn add_role(&mut self, role: &str) -> std::io::Result<()> {
+        write!(self.writer, r#""role":"{}""#, role)?;
+        Ok(())
+    }
+
+    pub fn start_content(&mut self) -> std::io::Result<()> {
+        self.writer.write_all(br#","content":["#)?;
+        Ok(())
+    }
+
+    pub fn start_text_item(&mut self) -> std::io::Result<()> {
+        self.writer.write_all(br#"{"type":"text""#)?;
+        Ok(())
+    }
+
+    pub fn add_text(&mut self, text: &str) -> std::io::Result<()> {
+        write!(self.writer, r#","text":"{}""#, text)?;
+        Ok(())
+    }
+
+    pub fn end_text_item(&mut self) -> std::io::Result<()> {
+        self.writer.write_all(b"}")?;
+        Ok(())
+    }
+
+    pub fn end_content(&mut self) -> std::io::Result<()> {
+        self.writer.write_all(b"]")?;
+        Ok(())
+    }
+
+    pub fn end_message(&mut self) -> std::io::Result<()> {
+        self.writer.write_all(b"}")?;
+        Ok(())
+    }
 }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -101,6 +101,8 @@ impl<W: Write> StructureBuilder<W> {
     pub fn begin_content(&mut self) -> Result<(), String> {
         self.message_content = Progress::WaitingForFirstChild;
         self.content_item = Progress::ChildrenAreUnexpected;
+        // Unlike for other containers, allow empty content
+        self.really_begin_content()?;
         Ok(())
     }
 

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -1,0 +1,16 @@
+use std::io::Write;
+
+pub struct StructureBuilder<W: Write> {
+    writer: W,
+}
+
+impl<W: Write> StructureBuilder<W> {
+    pub fn new(writer: W) -> Self {
+        StructureBuilder { writer }
+    }
+
+    #[must_use]
+    pub fn get_writer(&mut self) -> &mut W {
+        &mut self.writer
+    }
+}

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -8,8 +8,8 @@ pub enum Progress {
     ChildIsWritten, // to write the comma
 }
 
-fn is_write_started(progress: Progress) -> bool {
-    progress == Progress::WriteIsStarted || progress == Progress::ChildIsWritten
+fn is_write_started(progress: &Progress) -> bool {
+    matches!(progress, Progress::WriteIsStarted | Progress::ChildIsWritten)
 }
 
 pub struct StructureBuilder<W: Write> {
@@ -17,6 +17,7 @@ pub struct StructureBuilder<W: Write> {
     top: Progress,
     message: Progress,
     message_content: Progress,
+    content_item: Progress,
 }
 
 impl<W: Write> StructureBuilder<W> {
@@ -26,6 +27,7 @@ impl<W: Write> StructureBuilder<W> {
             top: Progress::WaitingForFirstChild,
             message: Progress::ChildrenAreUnexpected,
             message_content: Progress::ChildrenAreUnexpected,
+            content_item: Progress::ChildrenAreUnexpected,
         }
     }
 
@@ -36,90 +38,128 @@ impl<W: Write> StructureBuilder<W> {
 
     /// # Errors
     /// I/O
-    pub fn start_message(&mut self) -> std::io::Result<()> {
+    pub fn start_message(&mut self) -> Result<(), String> {
         self.message = Progress::WaitingForFirstChild;
         self.message_content = Progress::ChildrenAreUnexpected;
+        self.content_item = Progress::ChildrenAreUnexpected;
         Ok(())
     }
 
-    fn really_start_message(&mut self) -> std::Result<(), String> {
-        if self.message == Progress::ChildrenAreUnexpected {
+    fn really_start_message(&mut self) -> Result<(), String> {
+        if let Progress::ChildrenAreUnexpected = self.message {
             return Err("Message is not started".to_string());
         }
-        if is_write_started(self.message) {
-            return Ok();
+        if is_write_started(&self.message) {
+            return Ok(());
         }
-        if self.top == Progress::ChildIsWritten {
-            self.writer.write_all(b",")?;
+        if let Progress::ChildIsWritten = self.top {
+            self.writer.write_all(b",").map_err(|e| e.to_string())?;
         }
-        self.writer.write_all(b"{")?;
+        self.writer.write_all(b"{").map_err(|e| e.to_string())?;
         self.message = Progress::WriteIsStarted;
         Ok(())
     }
 
     /// # Errors
     /// I/O
-    pub fn end_message(&mut self) -> std::io::Result<()> {
-        if is_write_started(self.message) {
-            self.writer.write_all(b"}")?;
+    pub fn end_message(&mut self) -> Result<(), String> {
+        if is_write_started(&self.message) {
+            self.writer.write_all(b"}").map_err(|e| e.to_string())?;
             self.top = Progress::ChildIsWritten;
         }
+        self.message_content = Progress::ChildrenAreUnexpected;
+        self.content_item = Progress::ChildrenAreUnexpected;
         Ok(())
     }
 
     /// # Errors
     /// I/O
-    pub fn add_role(&mut self, role: &str) -> std::io::Result<()> {
+    pub fn add_role(&mut self, role: &str) -> Result<(), String> {
         self.really_start_message()?;
-        write!(self.writer, r#""role":"{role}""#)?;
-        Ok(())
-    }
-
-    /// # Errors
-    /// I/O
-    pub fn start_content(&mut self) -> std::io::Result<()> {
-        self.writer.write_all(br#","content":["#)?;
-        Ok(())
-    }
-
-    pub fn start_content_item(&mut self) -> std::io::Result<()> {
-        if self.should_write_div_content_item {
-            self.writer.write_all(b",")?;
+        if let Progress::ChildIsWritten = self.message {
+            self.writer.write_all(b",").map_err(|e| e.to_string())?;
         }
-        self.should_write_div_content_item = true;
+        write!(self.writer, r#""role":"{role}""#).map_err(|e| e.to_string())?;
+        self.message = Progress::ChildIsWritten;
         Ok(())
     }
 
     /// # Errors
     /// I/O
-    pub fn start_text_item(&mut self) -> std::io::Result<()> {
-        if self.should_write_div_content_item {
-            self.writer.write_all(b",")?;
+    pub fn start_content(&mut self) -> Result<(), String> {
+        self.message_content = Progress::WaitingForFirstChild;
+        self.content_item = Progress::ChildrenAreUnexpected;
+        Ok(())
+    }
+
+    fn really_start_content(&mut self) -> Result<(), String> {
+        if let Progress::ChildrenAreUnexpected = self.message_content {
+            return Err("Content is not started".to_string());
         }
-        self.writer.write_all(br#"{"type":"text""#)?;
-
-        self.should_write_div_content_item = true;
+        if is_write_started(&self.message_content) {
+            return Ok(());
+        }
+        self.really_start_message()?;
+        if let Progress::ChildIsWritten = self.message {
+            self.writer.write_all(b",").map_err(|e| e.to_string())?;
+        }
+        self.writer.write_all(br#""content":["#).map_err(|e| e.to_string())?;
+        self.message_content = Progress::WriteIsStarted;
         Ok(())
     }
 
     /// # Errors
     /// I/O
-    pub fn add_text(&mut self, text: &str) -> std::io::Result<()> {
-        write!(self.writer, r#","text":"{text}""#)?;
+    pub fn end_content(&mut self) -> Result<(), String> {
+        if is_write_started(&self.message_content) {
+            self.writer.write_all(b"]").map_err(|e| e.to_string())?;
+            self.message = Progress::ChildIsWritten;
+        }
+        self.content_item = Progress::ChildrenAreUnexpected;
+        Ok(())
+    }
+
+    pub fn start_content_item(&mut self) -> Result<(), String> {
+        self.content_item = Progress::WaitingForFirstChild;
+        Ok(())
+    }
+
+    fn really_start_content_item(&mut self) -> Result<(), String> {
+        if let Progress::ChildrenAreUnexpected = self.content_item {
+            return Err("Content item is not started".to_string());
+        }
+        if is_write_started(&self.content_item) {
+            return Ok(());
+        }
+        self.really_start_content()?;
+        if let Progress::ChildIsWritten = self.message_content {
+            self.writer.write_all(b",").map_err(|e| e.to_string())?;
+        }
+        self.writer.write_all(br#"{"type":"text""#).map_err(|e| e.to_string())?;
+        self.content_item = Progress::WriteIsStarted;
         Ok(())
     }
 
     /// # Errors
     /// I/O
-    pub fn end_text_item(&mut self) -> std::io::Result<()> {
-        self.writer.write_all(b"}")?;
+    pub fn end_content_item(&mut self) -> Result<(), String> {
+        if is_write_started(&self.content_item) {
+            self.writer.write_all(b"}").map_err(|e| e.to_string())?;
+            self.message_content = Progress::ChildIsWritten;
+        }
         Ok(())
     }
 
     /// # Errors
     /// I/O
-    pub fn end_content(&mut self) -> std::io::Result<()> {
-        self.writer.write_all(b"]")?;
+    pub fn add_text(&mut self, text: &str) -> Result<(), String> {
+        if let Progress::ChildrenAreUnexpected = self.content_item {
+            return Err("Content item is not started".to_string());
+        }
+        self.really_start_content_item()?;
+        self.writer.write_all(text.as_bytes()).map_err(|e| e.to_string())?;
+        self.writer.write_all(b"\"").map_err(|e| e.to_string())?;
+        self.content_item = Progress::ChildIsWritten;
         Ok(())
     }
 }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -215,12 +215,19 @@ impl<W: Write> StructureBuilder<W> {
     /// # Errors
     /// - content item is not started
     /// - I/O
-    pub fn add_text(&mut self, text: &str) -> Result<(), String> {
+    pub fn begin_text(&mut self) -> Result<(), String> {
         if let Progress::ChildrenAreUnexpected = self.content_item {
             return Err("Content item is not started".to_string());
         }
         self.add_item_type(String::from("text"))?;
-        write!(self.writer, r#","text":"{text}""#).map_err(|e| e.to_string())?;
+        write!(self.writer, r#","text":""#).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// # Errors
+    /// - I/O
+    pub fn end_text(&mut self) -> Result<(), String> {
+        write!(self.writer, "\"").map_err(|e| e.to_string())?;
         Ok(())
     }
 }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -9,7 +9,10 @@ pub enum Progress {
 }
 
 fn is_write_started(progress: &Progress) -> bool {
-    matches!(progress, Progress::WriteIsStarted | Progress::ChildIsWritten)
+    matches!(
+        progress,
+        Progress::WriteIsStarted | Progress::ChildIsWritten
+    )
 }
 
 pub struct StructureBuilder<W: Write> {
@@ -103,7 +106,9 @@ impl<W: Write> StructureBuilder<W> {
         if let Progress::ChildIsWritten = self.message {
             self.writer.write_all(b",").map_err(|e| e.to_string())?;
         }
-        self.writer.write_all(br#""content":["#).map_err(|e| e.to_string())?;
+        self.writer
+            .write_all(br#""content":["#)
+            .map_err(|e| e.to_string())?;
         self.message_content = Progress::WriteIsStarted;
         Ok(())
     }
@@ -119,6 +124,8 @@ impl<W: Write> StructureBuilder<W> {
         Ok(())
     }
 
+    /// # Errors
+    /// I/O
     pub fn begin_content_item(&mut self) -> Result<(), String> {
         self.content_item = Progress::WaitingForFirstChild;
         Ok(())
@@ -150,10 +157,16 @@ impl<W: Write> StructureBuilder<W> {
     }
 
     fn write_item_prologue(&mut self, item_type: &str) -> Result<(), String> {
-        self.writer.write_all(br#"{"type":""#).map_err(|e| e.to_string())?;
-        self.writer.write_all(item_type.as_bytes()).map_err(|e| e.to_string())?;
+        self.writer
+            .write_all(br#"{"type":""#)
+            .map_err(|e| e.to_string())?;
+        self.writer
+            .write_all(item_type.as_bytes())
+            .map_err(|e| e.to_string())?;
         self.writer.write_all(b"\",\"").map_err(|e| e.to_string())?;
-        self.writer.write_all(item_type.as_bytes()).map_err(|e| e.to_string())?;
+        self.writer
+            .write_all(item_type.as_bytes())
+            .map_err(|e| e.to_string())?;
         self.writer.write_all(b"\":").map_err(|e| e.to_string())?;
         Ok(())
     }
@@ -167,7 +180,9 @@ impl<W: Write> StructureBuilder<W> {
         self.really_begin_content_item()?;
         self.write_item_prologue("text")?;
         self.writer.write_all(b"\"").map_err(|e| e.to_string())?;
-        self.writer.write_all(text.as_bytes()).map_err(|e| e.to_string())?;
+        self.writer
+            .write_all(text.as_bytes())
+            .map_err(|e| e.to_string())?;
         self.writer.write_all(b"\"").map_err(|e| e.to_string())?;
         self.content_item = Progress::ChildIsWritten;
         Ok(())

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -2,11 +2,17 @@ use std::io::Write;
 
 pub struct StructureBuilder<W: Write> {
     writer: W,
+    has_message: bool,
+    has_content_item: bool,
 }
 
 impl<W: Write> StructureBuilder<W> {
     pub fn new(writer: W) -> Self {
-        StructureBuilder { writer }
+        StructureBuilder {
+            writer,
+            has_message: false,
+            has_content_item: false,
+        }
     }
 
     #[must_use]
@@ -17,7 +23,13 @@ impl<W: Write> StructureBuilder<W> {
     /// # Errors
     /// I/O
     pub fn start_message(&mut self) -> std::io::Result<()> {
+        if self.has_message {
+            self.writer.write_all(b",")?;
+        }
         self.writer.write_all(b"{")?;
+
+        self.has_message = true;
+        self.has_content_item = false;
         Ok(())
     }
 
@@ -38,7 +50,12 @@ impl<W: Write> StructureBuilder<W> {
     /// # Errors
     /// I/O
     pub fn start_text_item(&mut self) -> std::io::Result<()> {
+        if self.has_content_item {
+            self.writer.write_all(b",")?;
+        }
         self.writer.write_all(br#"{"type":"text""#)?;
+
+        self.has_content_item = true;
         Ok(())
     }
 

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -30,5 +30,5 @@ fn test_text_items() {
     let output_json: Value = serde_json::from_str(fix_json(&writer.get_output()).as_str())
         .expect("Failed to parse output as JSON");
 
-    assert_that!(input_json, equal_to(output_json));
+    assert_that!(output_json, equal_to(input_json));
 }

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -27,6 +27,8 @@ fn test_text_items() {
     let input_json: Value = serde_json::from_str(fix_json(&fixture_content).as_str())
         .expect("Failed to parse input as JSON");
     println!("output: {}", writer.get_output()); // FIXME
+    println!("output2: {}", fix_json(&writer.get_output())); // FIXME
+    println!("input: {}", fix_json(&fixture_content)); // FIXME
     let output_json: Value = serde_json::from_str(fix_json(&writer.get_output()).as_str())
         .expect("Failed to parse output as JSON");
 

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -6,6 +6,16 @@ use messages_to_query::_process_query;
 use serde_json::Value;
 use std::io::Cursor;
 
+fn parse_jsonl(jsonl: &str) -> serde_json::Result<Value> {
+    let lines: Vec<_> = jsonl.lines().filter(|line| !line.is_empty()).collect();
+    let vec_str = format!("[{}]", lines.join(","));
+
+    serde_json::from_str(&vec_str).map_err(|e| {
+        println!("Failed to parse JSON from: {}", vec_str);
+        e
+    })
+}
+
 #[test]
 fn test_text_items() {
     let fixture_content = std::fs::read_to_string("tests/fixture/text_items.txt")
@@ -15,10 +25,8 @@ fn test_text_items() {
 
     _process_query(reader, writer.clone()).unwrap();
 
-    let input_json: Value =
-        serde_json::from_str(&fixture_content).expect("Failed to parse input as JSON");
-    let output_json: Value =
-        serde_json::from_str(&writer.get_output()).expect("Failed to parse output as JSON");
+    let input_json = parse_jsonl(&fixture_content).expect("Failed to parse input as JSON");
+    let output_json = parse_jsonl(&writer.get_output()).expect("Failed to parse output as JSON");
 
     assert_that!(input_json, equal_to(output_json));
 }

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -6,14 +6,13 @@ use messages_to_query::_process_query;
 use serde_json::Value;
 use std::io::Cursor;
 
-fn parse_jsonl(jsonl: &str) -> serde_json::Result<Value> {
-    let lines: Vec<_> = jsonl.lines().filter(|line| !line.is_empty()).collect();
-    let vec_str = format!("[{}]", lines.join(","));
-
-    serde_json::from_str(&vec_str).map_err(|e| {
-        println!("Failed to parse JSON from: {}", vec_str);
-        e
-    })
+fn fix_json(json: &str) -> String {
+    if json.contains("}\n{") {
+        let json = json.replace("}\n{", "},\n{");
+        let json = format!("[{}]", json);
+        return json;
+    }
+    json.to_string()
 }
 
 #[test]
@@ -25,8 +24,11 @@ fn test_text_items() {
 
     _process_query(reader, writer.clone()).unwrap();
 
-    let input_json = parse_jsonl(&fixture_content).expect("Failed to parse input as JSON");
-    let output_json = parse_jsonl(&writer.get_output()).expect("Failed to parse output as JSON");
+    let input_json: Value = serde_json::from_str(fix_json(&fixture_content).as_str())
+        .expect("Failed to parse input as JSON");
+    println!("output: {}", writer.get_output()); // FIXME
+    let output_json: Value = serde_json::from_str(fix_json(&writer.get_output()).as_str())
+        .expect("Failed to parse output as JSON");
 
     assert_that!(input_json, equal_to(output_json));
 }

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -1,4 +1,7 @@
+#[macro_use]
+extern crate hamcrest;
 use actor_runtime_mocked::RcWriter;
+use hamcrest::prelude::*;
 use messages_to_query::_process_query;
 use serde_json::Value;
 use std::io::Cursor;
@@ -12,10 +15,10 @@ fn test_text_items() {
 
     _process_query(reader, writer.clone()).unwrap();
 
-    let input_json: Value = serde_json::from_str(&fixture_content)
-        .expect("Failed to parse input as JSON");
-    let output_json: Value = serde_json::from_str(&writer.get_output())
-        .expect("Failed to parse output as JSON"); 
+    let input_json: Value =
+        serde_json::from_str(&fixture_content).expect("Failed to parse input as JSON");
+    let output_json: Value =
+        serde_json::from_str(&writer.get_output()).expect("Failed to parse output as JSON");
 
     assert_that!(input_json, equal_to(output_json));
 }

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -41,3 +41,19 @@ fn test_text_items() {
         serde_json::from_str(&expected_output).expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
+
+#[test]
+fn input_as_array() {
+    let fixture_content = std::fs::read_to_string("tests/fixture/text_items_arr.txt")
+        .expect("Failed to read fixture file 'text_items_arr.txt'");
+    let reader = Cursor::new(fixture_content.clone());
+    let writer = RcWriter::new();
+
+    _process_query(reader, writer.clone()).unwrap();
+    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+        .expect("Failed to parse output as JSON");
+
+    let expected_json = serde_json::from_str(wrap_boilerplate(&fixture_content).as_str())
+        .expect("Failed to parse expected output as JSON");
+    assert_that!(output_json, equal_to(expected_json));
+}

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -19,7 +19,7 @@ fn wrap_boilerplate(s: &str) -> String {
     let s1 = r#"{ "url": "https://api.openai.com/v1/chat/completions","#;
     let s2 = r#""method": "POST","#;
     let s3 = r#""headers": { "Content-type": "application/json", "Authorization": "Bearer {{secret('openai','gpt4o')}}" },"#;
-    let s4 = r#""body": { "model": "gpt-4o", "messages": "#;
+    let s4 = r#""body": { "model": "gpt-4o-mini", "stream": true, "messages": "#;
     let s_end = "}}\n";
     let s = s.replace("_NL_", "\n");
     format!("{}\n{}\n{}\n{}{}{}", s1, s2, s3, s4, s, s_end)

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -1,0 +1,21 @@
+use actor_runtime_mocked::RcWriter;
+use messages_to_query::_process_query;
+use serde_json::Value;
+use std::io::Cursor;
+
+#[test]
+fn test_text_items() {
+    let fixture_content = std::fs::read_to_string("tests/fixture/text_items.txt")
+        .expect("Failed to read fixture file 'text_items.txt'");
+    let reader = Cursor::new(fixture_content.clone());
+    let writer = RcWriter::new();
+
+    _process_query(reader, writer.clone()).unwrap();
+
+    let input_json: Value = serde_json::from_str(&fixture_content)
+        .expect("Failed to parse input as JSON");
+    let output_json: Value = serde_json::from_str(&writer.get_output())
+        .expect("Failed to parse output as JSON"); 
+
+    assert_that!(input_json, equal_to(output_json));
+}

--- a/ailets-rs/messages_to_query/tests/fixture/text_items.txt
+++ b/ailets-rs/messages_to_query/tests/fixture/text_items.txt
@@ -1,2 +1,2 @@
-{"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant who answers in Spanish", "role": "system"}]}
+{"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant who answers in Spanish"}]}
 {"role": "user", "content": [{"type": "text", "text": "Hello!"}]}

--- a/ailets-rs/messages_to_query/tests/fixture/text_items.txt
+++ b/ailets-rs/messages_to_query/tests/fixture/text_items.txt
@@ -1,0 +1,2 @@
+{"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant who answers in Spanish", "role": "system"}]}
+{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}

--- a/ailets-rs/messages_to_query/tests/fixture/text_items_arr.txt
+++ b/ailets-rs/messages_to_query/tests/fixture/text_items_arr.txt
@@ -1,0 +1,5 @@
+[
+{"role": "system", "content": [{"type": "text", "text": "You are a helpful assistant who answers in Spanish"}]}
+,
+{"role": "user", "content": [{"type": "text", "text": "Hello!"}]}
+]

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -3,6 +3,7 @@ extern crate hamcrest;
 use actor_runtime_mocked::RcWriter;
 use hamcrest::prelude::*;
 use messages_to_query::structure_builder::StructureBuilder;
+use std::io::Write;
 
 #[test]
 fn happy_path_for_text() {
@@ -14,7 +15,9 @@ fn happy_path_for_text() {
     builder.add_role("user").unwrap();
     builder.begin_content().unwrap();
     builder.begin_content_item().unwrap();
-    builder.add_text("Hello!").unwrap();
+    builder.begin_text().unwrap();
+    write!(builder.get_writer(), "Hello!").unwrap();
+    builder.end_text().unwrap();
     builder.end_content_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
@@ -41,7 +44,9 @@ fn many_messages_and_items() {
     builder.add_role("user").unwrap();
     builder.begin_content().unwrap();
     builder.begin_content_item().unwrap();
-    builder.add_text("Text item of the first message").unwrap();
+    builder.begin_text().unwrap();
+    write!(builder.get_writer(), "Text item of the first message").unwrap();
+    builder.end_text().unwrap();
     builder.end_content_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
@@ -50,14 +55,14 @@ fn many_messages_and_items() {
     builder.add_role("assistant").unwrap();
     builder.begin_content().unwrap();
     builder.begin_content_item().unwrap();
-    builder
-        .add_text("First item of the second message")
-        .unwrap();
+    builder.begin_text().unwrap();
+    write!(builder.get_writer(), "First item of the second message").unwrap();
+    builder.end_text().unwrap();
     builder.end_content_item().unwrap();
     builder.begin_content_item().unwrap();
-    builder
-        .add_text("Second item of the second message")
-        .unwrap();
+    builder.begin_text().unwrap();
+    write!(builder.get_writer(), "Second item of the second message").unwrap();
+    builder.end_text().unwrap();
     builder.end_content_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
@@ -126,7 +131,9 @@ fn auto_generate_type_text() {
     builder.begin_content().unwrap();
 
     builder.begin_content_item().unwrap();
-    builder.add_text("hello").unwrap();
+    builder.begin_text().unwrap();
+    write!(builder.get_writer(), "hello").unwrap();
+    builder.end_text().unwrap();
     builder.end_content_item().unwrap();
 
     let expected = String::from("{\"content\":[\n{\"type\":\"text\",\"text\":\"hello\"}");
@@ -143,7 +150,9 @@ fn mix_type_text() {
 
     builder.begin_content_item().unwrap();
     builder.add_item_type(String::from("text")).unwrap();
-    builder.add_text("hello").unwrap();
+    builder.begin_text().unwrap();
+    write!(builder.get_writer(), "hello").unwrap();
+    builder.end_text().unwrap();
     builder.add_item_type(String::from("text")).unwrap();
     builder.end_content_item().unwrap();
 

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -26,3 +26,49 @@ fn happy_path_for_text() {
         ))
     );
 }
+#[test]
+fn many_messages_and_items() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+
+    builder.start_message().unwrap();
+    builder.add_role("user").unwrap();
+    builder.start_content().unwrap();
+    builder.start_text_item().unwrap();
+    builder.add_text("First message").unwrap();
+    builder.end_text_item().unwrap();
+    builder.end_content().unwrap();
+    builder.end_message().unwrap();
+
+    builder.start_message().unwrap();
+    builder.add_role("assistant").unwrap();
+    builder.start_content().unwrap();
+    builder.start_text_item().unwrap();
+    builder.add_text("First item").unwrap();
+    builder.end_text_item().unwrap();
+    builder.start_text_item().unwrap();
+    builder.add_text("Second item").unwrap();
+    builder.end_text_item().unwrap();
+    builder.end_content().unwrap();
+    builder.end_message().unwrap();
+
+    let text_item1 = r#"{"type":"text","text":"Text item of the first message"}"#;
+    let text_item2a = r#"{"type":"text","text":"First item of the second message"}"#;
+    let text_item2b = r#"{"type":"text","text":"Second item of the second message"}"#;
+
+    assert_that!(
+        writer.get_output(),
+        equal_to(format!(
+            "{}{}{}{}{}{}{}{}",
+            r#"{"role":"user","content":["#,
+            text_item1,
+            "]}",
+            r#"{"role":"assistant","content":["#,
+            text_item2a,
+            ",",
+            text_item2b,
+            "]}"
+        ))
+    );
+}

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -1,0 +1,8 @@
+use messages_to_query::structure_builder::StructureBuilder;
+use std::io::Cursor;
+
+#[test]
+fn can_create_structure_builder() {
+    let writer = Cursor::new(Vec::new());
+    let _builder = StructureBuilder::new(writer);
+}

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -5,6 +5,16 @@ use hamcrest::prelude::*;
 use messages_to_query::structure_builder::StructureBuilder;
 use std::io::Write;
 
+fn wrap_boilerplate(s: &str) -> String {
+    let s1 = r#"{ "url": "https://api.openai.com/v1/chat/completions","#;
+    let s2 = r#""method": "POST","#;
+    let s3 = r#""headers": { "Content-type": "application/json", "Authorization": "Bearer {{secret('openai','gpt4o')}}" },"#;
+    let s4 = r#""body": { "model": "gpt-4o", "messages": ["#;
+    let s_end = "]}}\n";
+    let s = s.replace("_NL_", "\n");
+    format!("{}\n{}\n{}\n{}{}{}", s1, s2, s3, s4, s, s_end)
+}
+
 #[test]
 fn happy_path_for_text() {
     let writer = RcWriter::new();
@@ -25,12 +35,9 @@ fn happy_path_for_text() {
 
     assert_that!(
         writer.get_output(),
-        equal_to(
-            String::from(
-                r#"{"role":"user","content":[_NL_{"type":"text","text":"Hello!"}_NL_]}_NL_"#
-            )
-            .replace("_NL_", "\n")
-        )
+        equal_to(wrap_boilerplate(
+            r#"{"role":"user","content":[_NL_{"type":"text","text":"Hello!"}_NL_]}"#
+        ))
     );
 }
 
@@ -72,9 +79,9 @@ fn many_messages_and_items() {
     let text_item2b = r#"{"type":"text","text":"Second item of the second message"}"#;
 
     let expected = String::from(
-            r#"{"role":"user","content":[_NL__TI1__NL_]},{"role":"assistant","content":[_NL__TI2a_,_NL__TI2b__NL_]}_NL_"#
-        ).replace("_NL_", "\n").replace("_TI1_", text_item1).replace("_TI2a_", text_item2a).replace("_TI2b_", text_item2b);
-
+            r#"{"role":"user","content":[_NL__TI1__NL_]},{"role":"assistant","content":[_NL__TI2a_,_NL__TI2b__NL_]}"#
+        ).replace("_TI1_", text_item1).replace("_TI2a_", text_item2a).replace("_TI2b_", text_item2b);
+    let expected = wrap_boilerplate(expected.as_str());
     assert_that!(writer.get_output(), equal_to(expected));
 }
 
@@ -118,7 +125,7 @@ fn skip_empty_content_items() {
     builder.end().unwrap();
 
     let empty_msg = "{\"content\":[\n\n]}".to_owned();
-    let two_empty_msgs = format!("{},{}\n", empty_msg, empty_msg);
+    let two_empty_msgs = wrap_boilerplate(format!("{},{}", empty_msg, empty_msg).as_str());
     assert_that!(writer.get_output(), equal_to(two_empty_msgs));
 }
 
@@ -135,8 +142,9 @@ fn auto_generate_type_text() {
     write!(builder.get_writer(), "hello").unwrap();
     builder.end_text().unwrap();
     builder.end_content_item().unwrap();
+    builder.get_writer().write_all(b"]}]}}\n").unwrap(); // boilerplate
 
-    let expected = String::from("{\"content\":[\n{\"type\":\"text\",\"text\":\"hello\"}");
+    let expected = wrap_boilerplate(r#"{"content":[_NL_{"type":"text","text":"hello"}]}"#);
     assert_that!(writer.get_output(), equal_to(expected));
 }
 
@@ -155,8 +163,9 @@ fn mix_type_text() {
     builder.end_text().unwrap();
     builder.add_item_type(String::from("text")).unwrap();
     builder.end_content_item().unwrap();
+    builder.get_writer().write_all(b"]}]}}\n").unwrap(); // boilerplate
 
-    let expected = String::from("{\"content\":[\n{\"type\":\"text\",\"text\":\"hello\"}");
+    let expected = wrap_boilerplate(r#"{"content":[_NL_{"type":"text","text":"hello"}]}"#);
     assert_that!(writer.get_output(), equal_to(expected));
 }
 
@@ -194,7 +203,7 @@ fn having_role_enforces_content() {
     builder.end_message().unwrap();
     builder.end().unwrap();
 
-    let expected = String::from("{\"role\":\"user\",\"content\":[\n\n]}\n");
+    let expected = wrap_boilerplate(r#"{"role":"user","content":[_NL__NL_]}"#);
     assert_that!(writer.get_output(), equal_to(expected));
 }
 
@@ -223,7 +232,12 @@ fn support_special_chars_and_unicode() {
     builder.end_message().unwrap();
     builder.end().unwrap();
 
-    let expected =
-        format!("{{\"content\":[\n{{\"type\":\"text\",\"text\":\"{special_chars}\"}}\n]}}\n");
+    let expected = wrap_boilerplate(
+        format!(
+            r#"{{"content":[_NL_{{"type":"text","text":"{}"}}_NL_]}}"#,
+            special_chars
+        )
+        .as_str(),
+    );
     assert_that!(writer.get_output(), equal_to(expected));
 }

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -9,7 +9,7 @@ fn wrap_boilerplate(s: &str) -> String {
     let s1 = r#"{ "url": "https://api.openai.com/v1/chat/completions","#;
     let s2 = r#""method": "POST","#;
     let s3 = r#""headers": { "Content-type": "application/json", "Authorization": "Bearer {{secret('openai','gpt4o')}}" },"#;
-    let s4 = r#""body": { "model": "gpt-4o", "messages": ["#;
+    let s4 = r#""body": { "model": "gpt-4o-mini", "stream": true, "messages": ["#;
     let s_end = "]}}\n";
     let s = s.replace("_NL_", "\n");
     format!("{}\n{}\n{}\n{}{}{}", s1, s2, s3, s4, s, s_end)

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -1,8 +1,28 @@
+#[macro_use]
+extern crate hamcrest;
+use actor_runtime_mocked::RcWriter;
+use hamcrest::prelude::*;
 use messages_to_query::structure_builder::StructureBuilder;
-use std::io::Cursor;
 
 #[test]
-fn can_create_structure_builder() {
-    let writer = Cursor::new(Vec::new());
-    let _builder = StructureBuilder::new(writer);
+fn happy_path_for_text() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+
+    builder.start_message().unwrap();
+    builder.add_role("user").unwrap();
+    builder.start_content().unwrap();
+    builder.start_text_item().unwrap();
+    builder.add_text("Hello!").unwrap();
+    builder.end_text_item().unwrap();
+    builder.end_content().unwrap();
+    builder.end_message().unwrap();
+
+    assert_that!(
+        writer.get_output(),
+        equal_to(String::from(
+            r#"{"role":"user","content":[{"type":"text","text":"Hello!"}]}"#
+        ))
+    );
 }

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -142,11 +142,34 @@ fn mix_type_text() {
     builder.begin_content().unwrap();
 
     builder.begin_content_item().unwrap();
-    builder.add_item_type("text").unwrap();
+    builder.add_item_type(String::from("text")).unwrap();
     builder.add_text("hello").unwrap();
-    builder.add_item_type("text").unwrap();
+    builder.add_item_type(String::from("text")).unwrap();
     builder.end_content_item().unwrap();
 
     let expected = String::from("{\"content\":[\n{\"type\":\"text\",\"text\":\"hello\"}");
     assert_that!(writer.get_output(), equal_to(expected));
+}
+
+#[test]
+fn reject_conflicting_type() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+    builder.begin_message().unwrap();
+    builder.begin_content().unwrap();
+
+    builder.begin_content_item().unwrap();
+    builder.add_item_type(String::from("text")).unwrap();
+    let err = builder.add_item_type(String::from("image")).unwrap_err();
+    assert_that!(
+        err,
+        equal_to(
+            "Wrong content item type: already typed as \"text\", new type is \"image\"".to_string()
+        )
+    );
+
+    // Different content items have different types
+    builder.begin_content_item().unwrap();
+    builder.add_item_type(String::from("image")).unwrap();
 }

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -112,6 +112,7 @@ fn skip_empty_content_items() {
     builder.end_message().unwrap();
     builder.end().unwrap();
 
-    let empty_msg = r#"{"role":"user","content":[]}"#.to_owned() + "\n";
-    assert_that!(writer.get_output(), equal_to(empty_msg.repeat(2)));
+    let empty_msg = "{\"content\":[\n\n]}".to_owned();
+    let two_empty_msgs = format!("{},{}\n", empty_msg, empty_msg);
+    assert_that!(writer.get_output(), equal_to(two_empty_msgs));
 }

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -173,3 +173,18 @@ fn reject_conflicting_type() {
     builder.begin_content_item().unwrap();
     builder.add_item_type(String::from("image")).unwrap();
 }
+
+#[test]
+fn having_role_enforces_content() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+
+    builder.begin_message().unwrap();
+    builder.add_role("user").unwrap();
+    builder.end_message().unwrap();
+    builder.end().unwrap();
+
+    let expected = String::from("{\"role\":\"user\",\"content\":[\n\n]}\n");
+    assert_that!(writer.get_output(), equal_to(expected));
+}

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -197,3 +197,33 @@ fn having_role_enforces_content() {
     let expected = String::from("{\"role\":\"user\",\"content\":[\n\n]}\n");
     assert_that!(writer.get_output(), equal_to(expected));
 }
+
+#[test]
+fn support_special_chars_and_unicode() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+
+    let special_chars = "Special chars: \"\\/\n\r\t\u{1F600}";
+
+    builder.begin_message().unwrap();
+    builder.begin_content().unwrap();
+
+    builder.begin_content_item().unwrap();
+    builder.add_item_type(String::from("text")).unwrap();
+    builder.begin_text().unwrap();
+    builder
+        .get_writer()
+        .write_all(special_chars.as_bytes())
+        .unwrap();
+    builder.end_text().unwrap();
+    builder.end_content_item().unwrap();
+
+    builder.end_content().unwrap();
+    builder.end_message().unwrap();
+    builder.end().unwrap();
+
+    let expected =
+        format!("{{\"content\":[\n{{\"type\":\"text\",\"text\":\"{special_chars}\"}}\n]}}\n");
+    assert_that!(writer.get_output(), equal_to(expected));
+}

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -10,12 +10,12 @@ fn happy_path_for_text() {
     let builder = StructureBuilder::new(writer.clone());
     let mut builder = builder;
 
-    builder.start_message().unwrap();
+    builder.begin_message().unwrap();
     builder.add_role("user").unwrap();
-    builder.start_content().unwrap();
-    builder.start_text_item().unwrap();
+    builder.begin_content().unwrap();
+    builder.begin_content_item().unwrap();
     builder.add_text("Hello!").unwrap();
-    builder.end_text_item().unwrap();
+    builder.end_content_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
 
@@ -32,28 +32,28 @@ fn many_messages_and_items() {
     let builder = StructureBuilder::new(writer.clone());
     let mut builder = builder;
 
-    builder.start_message().unwrap();
+    builder.begin_message().unwrap();
     builder.add_role("user").unwrap();
-    builder.start_content().unwrap();
-    builder.start_text_item().unwrap();
+    builder.begin_content().unwrap();
+    builder.begin_content_item().unwrap();
     builder.add_text("Text item of the first message").unwrap();
-    builder.end_text_item().unwrap();
+    builder.end_content_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
 
-    builder.start_message().unwrap();
+    builder.begin_message().unwrap();
     builder.add_role("assistant").unwrap();
-    builder.start_content().unwrap();
-    builder.start_text_item().unwrap();
+    builder.begin_content().unwrap();
+    builder.begin_content_item().unwrap();
     builder
         .add_text("First item of the second message")
         .unwrap();
-    builder.end_text_item().unwrap();
-    builder.start_text_item().unwrap();
+    builder.end_content_item().unwrap();
+    builder.begin_content_item().unwrap();
     builder
         .add_text("Second item of the second message")
         .unwrap();
-    builder.end_text_item().unwrap();
+    builder.end_content_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
 

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -36,7 +36,7 @@ fn many_messages_and_items() {
     builder.add_role("user").unwrap();
     builder.start_content().unwrap();
     builder.start_text_item().unwrap();
-    builder.add_text("First message").unwrap();
+    builder.add_text("Text item of the first message").unwrap();
     builder.end_text_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
@@ -45,10 +45,14 @@ fn many_messages_and_items() {
     builder.add_role("assistant").unwrap();
     builder.start_content().unwrap();
     builder.start_text_item().unwrap();
-    builder.add_text("First item").unwrap();
+    builder
+        .add_text("First item of the second message")
+        .unwrap();
     builder.end_text_item().unwrap();
     builder.start_text_item().unwrap();
-    builder.add_text("Second item").unwrap();
+    builder
+        .add_text("Second item of the second message")
+        .unwrap();
     builder.end_text_item().unwrap();
     builder.end_content().unwrap();
     builder.end_message().unwrap();
@@ -63,7 +67,7 @@ fn many_messages_and_items() {
             "{}{}{}{}{}{}{}{}",
             r#"{"role":"user","content":["#,
             text_item1,
-            "]}",
+            "]},",
             r#"{"role":"assistant","content":["#,
             text_item2a,
             ",",

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -116,3 +116,37 @@ fn skip_empty_content_items() {
     let two_empty_msgs = format!("{},{}\n", empty_msg, empty_msg);
     assert_that!(writer.get_output(), equal_to(two_empty_msgs));
 }
+
+#[test]
+fn auto_generate_type_text() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+    builder.begin_message().unwrap();
+    builder.begin_content().unwrap();
+
+    builder.begin_content_item().unwrap();
+    builder.add_text("hello").unwrap();
+    builder.end_content_item().unwrap();
+
+    let expected = String::from("{\"content\":[\n{\"type\":\"text\",\"text\":\"hello\"}");
+    assert_that!(writer.get_output(), equal_to(expected));
+}
+
+#[test]
+fn mix_type_text() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+    builder.begin_message().unwrap();
+    builder.begin_content().unwrap();
+
+    builder.begin_content_item().unwrap();
+    builder.add_item_type("text").unwrap();
+    builder.add_text("hello").unwrap();
+    builder.add_item_type("text").unwrap();
+    builder.end_content_item().unwrap();
+
+    let expected = String::from("{\"content\":[\n{\"type\":\"text\",\"text\":\"hello\"}");
+    assert_that!(writer.get_output(), equal_to(expected));
+}

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -85,6 +85,22 @@ fn skip_contentless_messages() {
     let mut builder = builder;
 
     builder.begin_message().unwrap();
+    builder.end_message().unwrap();
+    builder.begin_message().unwrap();
+    builder.end_message().unwrap();
+    builder.begin_message().unwrap();
+    builder.end_message().unwrap();
+
+    assert_that!(writer.get_output(), equal_to(String::new()));
+}
+
+#[test]
+fn skip_empty_content_items() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+
+    builder.begin_message().unwrap();
     builder.begin_content().unwrap();
     builder.begin_content_item().unwrap();
     builder.end_content_item().unwrap();
@@ -100,5 +116,6 @@ fn skip_contentless_messages() {
     builder.end_content().unwrap();
     builder.end_message().unwrap();
 
-    assert_that!(writer.get_output(), equal_to(String::new()));
+    let empty_msg = r#"{"role":"user","content":[]}"#.to_owned() + "\n";
+    assert_that!(writer.get_output(), equal_to(empty_msg.repeat(2)));
 }

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -26,6 +26,7 @@ fn happy_path_for_text() {
         ))
     );
 }
+
 #[test]
 fn many_messages_and_items() {
     let writer = RcWriter::new();
@@ -75,4 +76,29 @@ fn many_messages_and_items() {
             "]}"
         ))
     );
+}
+
+#[test]
+fn skip_contentless_messages() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone());
+    let mut builder = builder;
+
+    builder.begin_message().unwrap();
+    builder.begin_content().unwrap();
+    builder.begin_content_item().unwrap();
+    builder.end_content_item().unwrap();
+    builder.end_content().unwrap();
+    builder.end_message().unwrap();
+
+    builder.begin_message().unwrap();
+    builder.begin_content().unwrap();
+    builder.begin_content_item().unwrap();
+    builder.end_content_item().unwrap();
+    builder.begin_content_item().unwrap();
+    builder.end_content_item().unwrap();
+    builder.end_content().unwrap();
+    builder.end_message().unwrap();
+
+    assert_that!(writer.get_output(), equal_to(String::new()));
 }


### PR DESCRIPTION
- Create a new actor, a new rust package
- Structure the package similar to other actors
- New approach in StructureBuilder: use Progress
- Convert text items
- Generate the same structure as by Python actor

close #116 