### PR TITLE
A128 awaker use notification queue

### DIFF
--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -161,13 +161,25 @@ pub fn _process_gpt<W: Write>(
     let triggers_end = vec![end_message];
     let sse_tokens = vec!["data:", "DONE"];
 
-    scan(
+    let scan_result = scan(
         &triggers,
         &triggers_end,
         &sse_tokens,
         &rjiter_cell,
         &builder_cell,
-    )?;
+    );
+    // FIXME revert vebose handling
+    //scan_result?;
+    if let Err(e) = scan_result {
+        let mut wr2 = AWriter::new(c"log").unwrap();
+        wr2.write_all(b"Handling scan error\n").unwrap();
+        let rjiter = rjiter_cell.borrow();
+        wr2.write_all(format!("RJiter is: {rjiter:?}\n").as_bytes()).unwrap();
+        wr2.close().unwrap();
+
+        return Err(e.into());
+    }
+
     let mut builder = builder_cell.borrow_mut();
     builder.end_message()?;
 

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -301,7 +301,7 @@ async def main() -> None:
             with open(os.path.join(args.download_to, name), "wb") as hb:
                 content = await stream.read(0, -1)
                 hb.write(content)
-        env.processes.destroy()
+        env.destroy()
 
 
 if __name__ == "__main__":

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -301,6 +301,7 @@ async def main() -> None:
             with open(os.path.join(args.download_to, name), "wb") as hb:
                 content = await stream.read(0, -1)
                 hb.write(content)
+        env.processes.destroy()
 
 
 if __name__ == "__main__":

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -284,7 +284,13 @@ async def main() -> None:
         node_iter = env.processes.next_node_iter(
             target_node_name, args.one_step, stop_before_node, stop_after_node
         )
-        await env.processes.run_nodes(node_iter)
+        try:
+            await env.processes.run_nodes(node_iter)
+        except Exception as e:
+            with open("ailets-core-dump.json", "w") as f:
+                await dump_environment(env, f)
+            raise e
+
         # Reset SIGTSTP handler back to default
         signal.signal(signal.SIGTSTP, signal.SIG_DFL)
 

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -94,9 +94,6 @@ class IStreams(Protocol):
     async def read_dir(self, dir_name: str, node_names: Sequence[str]) -> Sequence[str]:
         raise NotImplementedError
 
-    def set_on_write_started(self, func: Callable[[], None]) -> None:
-        raise NotImplementedError
-
 
 #
 #

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -74,6 +74,12 @@ class IStreams(Protocol):
     ) -> Stream:
         raise NotImplementedError
 
+    def destroy(self) -> None:
+        raise NotImplementedError
+
+    def get_fsops_handle(self) -> int:
+        raise NotImplementedError
+
     def has_input(self, dep: "Dependency") -> bool:
         raise NotImplementedError
 

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass, field
-import threading
 from typing import (
     Any,
     Awaitable,
@@ -16,6 +15,7 @@ from typing import (
     Union,
 )
 from typing_extensions import NotRequired
+from ailets.cons.notification_queue import INotificationQueue
 from ailets.cons.seqno import Seqno
 
 
@@ -39,17 +39,6 @@ class IAsyncWriter(Protocol):
         raise NotImplementedError
 
     def tell(self) -> int:
-        raise NotImplementedError
-
-
-class INotificationQueue(Protocol):
-    def notify(self, handle: int) -> None:
-        raise NotImplementedError
-
-    async def wait_for_handle(self, handle: int, debug_hint: str) -> None:
-        raise NotImplementedError
-
-    def get_lock(self) -> threading.Lock:
         raise NotImplementedError
 
 

--- a/pylib-v1/ailets/cons/bytesrw.py
+++ b/pylib-v1/ailets/cons/bytesrw.py
@@ -32,7 +32,7 @@ class Writer(IAsyncWriter):
         if self.closed:
             raise ValueError("Writer is closed")
         self.buffer.extend(data)
-        self.queue.notify(self.handle)
+        self.queue.notify(self.handle, len(data))
         return len(data)
 
     def tell(self) -> int:
@@ -41,7 +41,7 @@ class Writer(IAsyncWriter):
     def close(self) -> None:
         self.closed = True
         self.queue.unlist(self.handle)
-        self.queue.notify(self.handle)
+        self.queue.notify(self.handle, -1)
 
 
 class Reader(IAsyncReader):

--- a/pylib-v1/ailets/cons/bytesrw.py
+++ b/pylib-v1/ailets/cons/bytesrw.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
 
-from .notification_queue import NotificationQueue
-from .atyping import IAsyncReader, IAsyncWriter, INotificationQueue
+from .atyping import IAsyncReader, IAsyncWriter
+from .notification_queue import INotificationQueue, NotificationQueue
 
 logger = logging.getLogger("ailets.io")
 

--- a/pylib-v1/ailets/cons/bytesrw.py
+++ b/pylib-v1/ailets/cons/bytesrw.py
@@ -83,7 +83,7 @@ class Reader(IAsyncReader):
         lock = self.writer.queue.get_lock()
         with lock:
             if self._should_wait_with_autoclose():
-                await self.writer.queue.wait_for_handle_unsafe(
+                await self.writer.queue.wait_unsafe(
                     self.writer.handle, f"BytesWR.Reader {self.handle}"
                 )
                 lock.acquire()

--- a/pylib-v1/ailets/cons/bytesrw.py
+++ b/pylib-v1/ailets/cons/bytesrw.py
@@ -31,6 +31,8 @@ class Writer(IAsyncWriter):
     def write_sync(self, data: bytes) -> int:
         if self.closed:
             raise ValueError("Writer is closed")
+        if len(data) == 0:
+            return 0
         self.buffer.extend(data)
         self.queue.notify(self.handle, len(data))
         return len(data)

--- a/pylib-v1/ailets/cons/environment.py
+++ b/pylib-v1/ailets/cons/environment.py
@@ -18,5 +18,5 @@ class Environment(IEnvironment):
         self.processes = Processes(self)
 
     def destroy(self) -> None:
-        self.streams.destroy()
         self.processes.destroy()
+        self.streams.destroy()

--- a/pylib-v1/ailets/cons/environment.py
+++ b/pylib-v1/ailets/cons/environment.py
@@ -16,3 +16,7 @@ class Environment(IEnvironment):
         self.streams = Streams(self.notification_queue, self.seqno)
         self.nodereg = nodereg
         self.processes = Processes(self)
+
+    def destroy(self) -> None:
+        self.streams.destroy()
+        self.processes.destroy()

--- a/pylib-v1/ailets/cons/minishell.py
+++ b/pylib-v1/ailets/cons/minishell.py
@@ -1,4 +1,5 @@
 import cmd
+import asyncio
 from ailets.cons.environment import Environment
 
 
@@ -43,6 +44,16 @@ class MiniShell(cmd.Cmd):
         """List waits."""
         for handle, clients in self.env.notification_queue.get_waits():
             print(f"{handle}: {clients}")
+
+    def do_tasks(self, arg: str) -> None:
+        """List tasks."""
+        tasks = asyncio.all_tasks()
+        for task in tasks:
+            print(
+                f"Task {task.get_name()} - "
+                f"Cancelled: {task.cancelled()}, "
+                f"Done: {task.done()}"
+            )
 
     # Aliases
     do_quit = do_exit

--- a/pylib-v1/ailets/cons/minishell.py
+++ b/pylib-v1/ailets/cons/minishell.py
@@ -32,7 +32,7 @@ class MiniShell(cmd.Cmd):
 
     def do_awake(self, arg: str) -> bool:
         """Awake a process."""
-        self.env.notification_queue.notify(self.env.processes.get_progress_handle())
+        self.env.notification_queue.notify(self.env.processes.get_progress_handle(), -1)
         return True
 
     def do_streams(self, arg: str) -> None:

--- a/pylib-v1/ailets/cons/minishell.py
+++ b/pylib-v1/ailets/cons/minishell.py
@@ -31,7 +31,7 @@ class MiniShell(cmd.Cmd):
 
     def do_awake(self, arg: str) -> bool:
         """Awake a process."""
-        self.env.processes.mark_node_started_writing()
+        self.env.notification_queue.notify(self.env.processes.get_progress_handle())
         return True
 
     def do_streams(self, arg: str) -> None:

--- a/pylib-v1/ailets/cons/notification_queue.py
+++ b/pylib-v1/ailets/cons/notification_queue.py
@@ -48,6 +48,12 @@ class INotificationQueue(Protocol):
     def notify(self, handle: int) -> None:
         raise NotImplementedError
 
+    def whitelist(self, handle: int, debug_hint: str) -> None:
+        raise NotImplementedError
+
+    def unlist(self, handle: int) -> None:
+        raise NotImplementedError
+
     async def wait_for_handle_unsafe(self, handle: int, debug_hint: str) -> None:
         raise NotImplementedError
 
@@ -161,3 +167,9 @@ class DummyNotificationQueue(INotificationQueue):
 
     def get_waits(self) -> list[tuple[int, list[str]]]:
         return []
+
+    def whitelist(self, handle: int, debug_hint: str) -> None:
+        pass
+
+    def unlist(self, handle: int) -> None:
+        pass

--- a/pylib-v1/ailets/cons/notification_queue.py
+++ b/pylib-v1/ailets/cons/notification_queue.py
@@ -107,7 +107,7 @@ class NotificationQueue:
     def get_waits(self) -> list[tuple[int, list[str]]]:
         with self._lock:
             return [
-                (handle, [str(client) for client in clients])
+                (handle, [f"{str(client)}@{id(client)}" for client in clients])
                 for handle, clients in self._waiting_clients.items()
             ]
 

--- a/pylib-v1/ailets/cons/notification_queue.py
+++ b/pylib-v1/ailets/cons/notification_queue.py
@@ -1,7 +1,7 @@
 import asyncio
 from dataclasses import dataclass
 import logging
-from typing import Dict, Set
+from typing import Dict, Protocol, Set
 import threading
 
 """
@@ -44,6 +44,17 @@ with lock:
 logger = logging.getLogger("ailets.queue")
 
 
+class INotificationQueue(Protocol):
+    def notify(self, handle: int) -> None:
+        raise NotImplementedError
+
+    async def wait_for_handle(self, handle: int, debug_hint: str) -> None:
+        raise NotImplementedError
+
+    def get_lock(self) -> threading.Lock:
+        raise NotImplementedError
+
+
 @dataclass(frozen=True)
 class WaitingClient:
     """Represents a client waiting for a handle notification"""
@@ -64,7 +75,7 @@ class WaitingClient:
         return f"WaitingClient({self.debug_hint})"
 
 
-class NotificationQueue:
+class NotificationQueue(INotificationQueue):
     """Thread-safe queue for handle (as integers) notifications"""
 
     def __init__(self) -> None:
@@ -112,7 +123,7 @@ class NotificationQueue:
             ]
 
 
-class DummyNotificationQueue:
+class DummyNotificationQueue(INotificationQueue):
     def get_lock(self) -> threading.Lock:
         return threading.Lock()
 

--- a/pylib-v1/ailets/cons/notification_queue.py
+++ b/pylib-v1/ailets/cons/notification_queue.py
@@ -225,10 +225,14 @@ class NotificationQueue(INotificationQueue):
     def _notify_and_delete(self, handle: int, delete_subscribed: bool) -> None:
         with self._lock:
             clients1 = self._waiting_clients.get(handle, set())
-            del self._waiting_clients[handle]
+            if handle in self._waiting_clients:
+                del self._waiting_clients[handle]
             if delete_subscribed:
-                clients2 = self._subscribed_clients.get(handle, set())
-                del self._subscribed_clients[handle]
+                if handle in self._subscribed_clients:
+                    clients2 = self._subscribed_clients[handle]
+                    del self._subscribed_clients[handle]
+                else:
+                    clients2 = set()
             else:
                 clients2 = self._subscribed_clients.get(handle, set()).copy()
         logger.debug(

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -196,6 +196,11 @@ class Processes(IProcesses):
                 print(f"  {dep.source} ({dep.stream}) -> {dep.name}")
             print(f"Exception: {exc}")
             raise
+        finally:
+            self.queue.notify(self.progress_handle)
 
     def get_processes(self) -> set[asyncio.Task[None]]:
         return self.pool
+
+    def get_progress_handle(self) -> int:
+        return self.progress_handle

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -37,8 +37,8 @@ class Processes(IProcesses):
         self.queue.unlist(self.progress_handle)
 
     def subscribe_fsops(self) -> None:
-        def on_fsops() -> None:
-            print("!!!!!!!!!!!! FS ops")
+        def on_fsops(writer_handle: int) -> None:
+            print("!!!!!!!!!!!! FS ops", writer_handle)
 
         self.fsops_subscription_id = self.queue.subscribe(
             self.streams.get_fsops_handle(), on_fsops, "Processes: observe fsops"
@@ -220,7 +220,7 @@ class Processes(IProcesses):
             print(f"Exception: {exc}")
             raise
         finally:
-            self.queue.notify(self.progress_handle)
+            self.queue.notify(self.progress_handle, -1)
 
     def get_processes(self) -> set[asyncio.Task[None]]:
         return self.pool

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -142,9 +142,7 @@ class Processes(IProcesses):
         async def awaker() -> None:
             lock = self.queue.get_lock()
             lock.acquire()
-            await self.queue.wait_for_handle_unsafe(
-                self.progress_handle, "process.awaker"
-            )
+            await self.queue.wait_unsafe(self.progress_handle, "process.awaker")
 
         def extend_pool() -> None:
             node_names: Sequence[str] = list(

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -37,7 +37,7 @@ class Processes(IProcesses):
         self.queue.unlist(self.progress_handle)
 
     def subscribe_fsops(self) -> None:
-        async def on_fsops() -> None:
+        def on_fsops() -> None:
             print("!!!!!!!!!!!! FS ops")
 
         self.fsops_subscription_id = self.queue.subscribe(

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -189,9 +189,10 @@ class Processes(IProcesses):
         )
         self.pool.add(awaker_task)
 
-        while len(self.pool) > 1:  # The awaker is always in the pool
+        while len(self.pool) > 0:  # The awaker is always in the pool
             if awaker_task.done():
-                self.pool.remove(awaker_task)
+                if awaker_task in self.pool:
+                    self.pool.remove(awaker_task)
                 awaker_task = asyncio.create_task(awaker(), name="process.awaker")
                 self.pool.add(awaker_task)
 
@@ -205,7 +206,8 @@ class Processes(IProcesses):
             extend_pool()
 
         awaker_task.cancel()
-        self.pool.remove(awaker_task)
+        if awaker_task in self.pool:
+            self.pool.remove(awaker_task)
 
     async def build_node_alone(self, name: str) -> None:
         """Build a node. Does not build its dependencies."""

--- a/pylib-v1/ailets/cons/streams.py
+++ b/pylib-v1/ailets/cons/streams.py
@@ -59,6 +59,7 @@ class StaticStream(IPipe):
     def __init__(self, content: bytes) -> None:
         writer = BytesWRWriter(handle=-1, queue=DummyNotificationQueue())
         writer.write_sync(content)
+        writer.close()
         self.writer = writer
 
     def get_reader(self, handle: int) -> IAsyncReader:

--- a/pylib-v1/ailets/cons/streams.py
+++ b/pylib-v1/ailets/cons/streams.py
@@ -138,14 +138,14 @@ class Streams(IStreams):
                 stream_name=stream_name,
                 pipe=log_pipe,
             )
-            self.queue.notify(self.fsops_handle)
             return stream
 
         if self._find_stream(node_name, stream_name) is not None:
             raise ValueError(f"Stream already exists: {node_name}.{stream_name}")
 
+        writer_handle = self.seqno.next_seqno()
         pipe = BytesWR(
-            writer_handle=self.seqno.next_seqno(),
+            writer_handle=writer_handle,
             queue=self.queue,
             debug_hint=f"{node_name}.{stream_name}",
         )
@@ -164,7 +164,7 @@ class Streams(IStreams):
         logger.debug(f"Created stream: {stream}")
 
         self._streams.append(stream)
-        self.queue.notify(self.fsops_handle)
+        self.queue.notify(self.fsops_handle, writer_handle)
         return stream
 
     async def mark_finished(self, node_name: str, stream_name: Optional[str]) -> None:

--- a/pylib-v1/ailets/cons/streams.py
+++ b/pylib-v1/ailets/cons/streams.py
@@ -55,8 +55,12 @@ class PrintStream(IPipe):
 
 
 class StaticStream(IPipe):
-    def __init__(self, content: bytes) -> None:
-        writer = BytesWRWriter(handle=-1, queue=DummyNotificationQueue())
+    def __init__(self, content: bytes, debug_hint: str) -> None:
+        writer = BytesWRWriter(
+            handle=-1,
+            queue=DummyNotificationQueue(),
+            debug_hint=debug_hint,
+        )
         writer.write_sync(content)
         writer.close()
         self.writer = writer
@@ -125,6 +129,7 @@ class Streams(IStreams):
         pipe = BytesWR(
             writer_handle=self.seqno.next_seqno(),
             queue=self.queue,
+            debug_hint=f"{node_name}.{stream_name}",
         )
         writer = pipe.get_writer()
         if isinstance(writer, BytesWRWriter):
@@ -151,7 +156,7 @@ class Streams(IStreams):
     @staticmethod
     def make_env_stream(params: Dict[str, Any]) -> Stream:
         content = json.dumps(params).encode("utf-8")
-        pipe = StaticStream(content)
+        pipe = StaticStream(content, "env")
         return Stream(
             node_name=".",
             stream_name="env",

--- a/pylib-v1/ailets/cons/streams.py
+++ b/pylib-v1/ailets/cons/streams.py
@@ -8,7 +8,6 @@ from ailets.cons.atyping import (
     IAsyncReader,
     IAsyncWriter,
     IStreams,
-    INotificationQueue,
     IPipe,
     Stream,
 )
@@ -17,7 +16,7 @@ from ailets.cons.bytesrw import (
     Writer as BytesWRWriter,
     Reader as BytesWRReader,
 )
-from ailets.cons.notification_queue import DummyNotificationQueue
+from ailets.cons.notification_queue import DummyNotificationQueue, INotificationQueue
 from ailets.cons.seqno import Seqno
 
 import logging


### PR DESCRIPTION
- Remove the old logic of `on_write_started`
- Notify the end of a process and stream creation through the queue
- `awaker` to wait on the queue
- Show handles in the mini-shell
- Add handle whitelisting to the notification queue
- Add subscribe in addition of wait
- Dump core on error
- To fix: collecting out-files, https://github.com/olpa/ailets/issues/130
- To fix: Heisenbug: unhandled Peek: https://github.com/olpa/ailets/issues/134

close #128 