### PR TITLE
I132 merge input stream in the orchestrator

### DIFF
--- a/ailets-rs/actor_io/tests/areader_test.rs
+++ b/ailets-rs/actor_io/tests/areader_test.rs
@@ -6,9 +6,7 @@ use std::io::Read;
 fn happy_path() {
     clear_mocks();
 
-    add_file("test.0".to_string(), b"foo".to_vec());
-    add_file("test.1".to_string(), b"bar".to_vec());
-    add_file("test.2".to_string(), b"baz".to_vec());
+    add_file("test".to_string(), b"foo".to_vec());
 
     let mut reader = AReader::new(c"test").expect("Should create reader");
     let mut result = String::new();
@@ -17,7 +15,7 @@ fn happy_path() {
         .read_to_string(&mut result)
         .expect("Should read all content");
 
-    assert_eq!(result, "foobarbaz");
+    assert_eq!(result, "foo");
 }
 
 #[test]
@@ -25,10 +23,9 @@ fn read_in_chunks() {
     clear_mocks();
 
     add_file(
-        "chunks.0".to_string(),
+        "chunks".to_string(),
         b"first\nchunk\nthird\nfourth\nfifth".to_vec(),
     );
-    add_file("chunks.1".to_string(), b"next\nfile\ncontents".to_vec());
 
     let mut reader = AReader::new(c"chunks").expect("Should create reader");
     let mut buf = [0u8; 10];
@@ -47,22 +44,7 @@ fn read_in_chunks() {
         .read_to_string(&mut result)
         .expect("Should read remaining content");
 
-    assert_eq!(result, "third\nfourth\nfifthnext\nfile\ncontents");
-}
-
-#[test]
-fn skip_empty_streams_in_read() {
-    clear_mocks();
-
-    add_file("empty.0".to_string(), b"".to_vec());
-    add_file("empty.1".to_string(), b"".to_vec());
-    add_file("empty.2".to_string(), b"contents".to_vec());
-
-    let mut reader = AReader::new(c"empty").expect("Should create reader");
-
-    let mut buf = [0u8; 10];
-    let n = reader.read(&mut buf).unwrap();
-    assert_eq!(&buf[..n], b"contents");
+    assert_eq!(result, "third\nfourth\nfifth");
 }
 
 #[test]
@@ -78,37 +60,16 @@ fn cant_open_nonexistent_file() {
 }
 
 #[test]
-fn close_can_raise_error() {
-    clear_mocks();
-
-    add_file("fname-close-error.0".to_string(), b"foo".to_vec());
-
-    let mut reader = AReader::new(c"fname-close-error").expect("Should create reader");
-
-    // Mock a close error by clearing the mocks while file is still open
-    clear_mocks();
-    let err = reader.close().expect_err("Should fail to close");
-    assert!(
-        err.to_string().contains("fname-close-error"),
-        "Error message should contain the stream name"
-    );
-}
-
-#[test]
 fn read_error() {
     clear_mocks();
 
     add_file(
-        "fname-read-error.0".to_string(),
+        "fname-read-error".to_string(),
         vec![actor_runtime_mocked::WANT_ERROR as u8],
     );
 
     let mut reader = AReader::new(c"fname-read-error").expect("Should create reader");
     let mut buf = [0u8; 10];
 
-    let err = reader.read(&mut buf).expect_err("Should fail to read");
-    assert!(
-        err.to_string().contains("fname-read-error"),
-        "Error message should contain the stream name"
-    );
+    reader.read(&mut buf).expect_err("Should fail to read");
 }

--- a/ailets-rs/actor_runtime/src/actor_runtime.rs
+++ b/ailets-rs/actor_runtime/src/actor_runtime.rs
@@ -2,8 +2,7 @@ use std::os::raw::{c_char, c_int, c_uint};
 
 #[link(wasm_import_module = "")]
 extern "C" {
-    pub fn n_of_streams(name_ptr: *const c_char) -> c_int;
-    pub fn open_read(name_ptr: *const c_char, index: c_uint) -> c_int;
+    pub fn open_read(name_ptr: *const c_char) -> c_int;
     pub fn open_write(name_ptr: *const c_char) -> c_int;
     pub fn aread(fd: c_int, buffer_ptr: *mut u8, count: c_uint) -> c_int;
     pub fn awrite(fd: c_int, buffer_ptr: *const u8, count: c_uint) -> c_int;

--- a/ailets-rs/actor_runtime/src/lib.rs
+++ b/ailets-rs/actor_runtime/src/lib.rs
@@ -4,7 +4,7 @@ mod actor_runtime;
 #[cfg(feature = "dagops")]
 mod dagops;
 
-pub use actor_runtime::{aclose, aread, awrite, n_of_streams, open_read, open_write};
+pub use actor_runtime::{aclose, aread, awrite, open_read, open_write};
 #[cfg(feature = "dagops")]
 pub use dagops::{DagOps, DagOpsTrait};
 

--- a/ailets-rs/actor_runtime_mocked/src/vfs.rs
+++ b/ailets-rs/actor_runtime_mocked/src/vfs.rs
@@ -73,30 +73,11 @@ fn cstr_to_string(ptr: *const c_char) -> String {
 #[no_mangle]
 #[allow(clippy::missing_panics_doc)]
 #[allow(clippy::unwrap_used)]
-pub extern "C" fn n_of_streams(name_ptr: *const c_char) -> c_int {
-    let files = FILES.lock().unwrap();
-
-    let name = cstr_to_string(name_ptr);
-    if name.contains(WANT_ERROR) {
-        return -1;
-    }
-
-    let mut count = 0;
-    while files.iter().any(|f| f.name == format!("{name}.{count}")) {
-        count += 1;
-    }
-    count
-}
-
-#[no_mangle]
-#[allow(clippy::missing_panics_doc)]
-#[allow(clippy::unwrap_used)]
-pub extern "C" fn open_read(name_ptr: *const c_char, index: c_uint) -> c_int {
+pub extern "C" fn open_read(name_ptr: *const c_char) -> c_int {
     let files = FILES.lock().unwrap();
     let mut handles = HANDLES.lock().unwrap();
 
     let name = cstr_to_string(name_ptr);
-    let name = format!("{name}.{index}");
 
     if let Some(vfs_index) = files.iter().position(|f| f.name == name) {
         let handle = FileHandle { vfs_index, pos: 0 };

--- a/ailets-rs/actor_runtime_mocked/tests/vfs_test.rs
+++ b/ailets-rs/actor_runtime_mocked/tests/vfs_test.rs
@@ -1,42 +1,12 @@
 use actor_runtime_mocked::vfs::{
-    aclose, add_file, aread, awrite, clear_mocks, get_file, n_of_streams, open_read, open_write,
-    WANT_ERROR,
+    aclose, add_file, aread, awrite, clear_mocks, get_file, open_read, open_write, WANT_ERROR,
 };
 use std::os::raw::c_uint;
 
 #[test]
-fn n_of_streams_returns_zero() {
-    clear_mocks();
-    let n = n_of_streams(c"test".as_ptr());
-    assert_eq!(n, 0);
-}
-
-#[test]
-fn n_of_streams_returns_number_of_sequential_files() {
-    clear_mocks();
-    let name = c"foo";
-    let name_str = name.to_str().unwrap();
-    for i in [0, 1, 2, 10] {
-        add_file(format!("{name_str}.{i}"), Vec::new());
-    }
-
-    let n = n_of_streams(name.as_ptr());
-
-    // Should only count sequential files (0,1,2) and not 10
-    assert_eq!(n, 3);
-}
-
-#[test]
-fn n_of_streams_returns_minus_one_on_error() {
-    clear_mocks();
-    let n = n_of_streams(c"test\u{1}".as_ptr());
-    assert_eq!(n, -1);
-}
-
-#[test]
 fn open_read_returns_minus_one_if_file_not_found() {
     clear_mocks();
-    let fd = open_read(c"test".as_ptr(), 0);
+    let fd = open_read(c"test".as_ptr());
     assert_eq!(fd, -1);
 }
 
@@ -44,8 +14,8 @@ fn open_read_returns_minus_one_if_file_not_found() {
 fn open_read_returns_non_negative_if_file_exists() {
     clear_mocks();
 
-    add_file("test.0".to_string(), Vec::new());
-    let fd = open_read(c"test".as_ptr(), 0);
+    add_file("test".to_string(), Vec::new());
+    let fd = open_read(c"test".as_ptr());
 
     assert!(fd >= 0);
 }
@@ -88,10 +58,10 @@ fn close_returns_minus_one_for_invalid_handle() {
 #[test]
 fn close_returns_zero_if_ok_for_read_and_write_handles() {
     clear_mocks();
-    add_file("foo.0".to_string(), Vec::new());
+    add_file("foo".to_string(), Vec::new());
 
     // Open handles
-    let read_fd = open_read(c"foo".as_ptr(), 0);
+    let read_fd = open_read(c"foo".as_ptr());
     assert!(read_fd >= 0);
     let write_fd = open_write(c"bar".as_ptr());
     assert!(write_fd >= 0);
@@ -119,10 +89,10 @@ fn read_returns_all_content() {
 
     // Create test file
     let content = b"Hello World!";
-    add_file("test.0".to_string(), content.to_vec());
+    add_file("test".to_string(), content.to_vec());
 
     // Open file for reading
-    let fd = open_read(c"test".as_ptr(), 0);
+    let fd = open_read(c"test".as_ptr());
     assert!(fd >= 0);
 
     // Read entire content
@@ -143,10 +113,10 @@ fn read_in_chunks_with_io_interrupt() {
 
     // Create test file with IO_INTERRUPT character
     let file_content = format!("one\ntwo\nthree\nx{WANT_ERROR}x");
-    add_file("test.0".to_string(), file_content.as_bytes().to_vec());
+    add_file("test".to_string(), file_content.as_bytes().to_vec());
 
     // Open file for reading
-    let fd = open_read(c"test".as_ptr(), 0);
+    let fd = open_read(c"test".as_ptr());
     assert!(fd >= 0);
 
     // Read first chunk

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -161,25 +161,13 @@ pub fn _process_gpt<W: Write>(
     let triggers_end = vec![end_message];
     let sse_tokens = vec!["data:", "DONE"];
 
-    let scan_result = scan(
+    scan(
         &triggers,
         &triggers_end,
         &sse_tokens,
         &rjiter_cell,
         &builder_cell,
-    );
-    // FIXME revert vebose handling
-    //scan_result?;
-    if let Err(e) = scan_result {
-        let mut wr2 = AWriter::new(c"log").unwrap();
-        wr2.write_all(b"Handling scan error\n").unwrap();
-        let rjiter = rjiter_cell.borrow();
-        wr2.write_all(format!("RJiter is: {rjiter:?}\n").as_bytes()).unwrap();
-        wr2.close().unwrap();
-
-        return Err(e.into());
-    }
-
+    )?;
     let mut builder = builder_cell.borrow_mut();
     builder.end_message()?;
 

--- a/ailets-rs/run_actor.py
+++ b/ailets-rs/run_actor.py
@@ -87,9 +87,6 @@ class NodeRuntime:
             return found
         return [Spec(direction=direction, name="", value_or_file="-")]
 
-    def n_of_streams(self, stream_name: str) -> int:
-        return len(self._collect_streams("in", stream_name))
-
     def open_read(self, stream_name: str) -> int:
         specs = self._collect_streams("in", stream_name)
         if not specs:
@@ -205,10 +202,6 @@ def register_node_runtime(
     nr: NodeRuntime,
 ) -> None:
 
-    def n_of_streams(name_ptr: int) -> int:
-        name = buf_to_str.get_string(name_ptr)
-        return nr.n_of_streams(name)
-
     def open_read(name_ptr: int) -> int:
         name = buf_to_str.get_string(name_ptr)
         return nr.open_read(name)
@@ -250,7 +243,6 @@ def register_node_runtime(
     import_object.register(
         "",
         {
-            "n_of_streams": wasmer.Function(store, n_of_streams),
             "open_read": wasmer.Function(store, open_read),
             "open_write": wasmer.Function(store, open_write),
             "aread": wasmer.Function(store, aread),

--- a/ailets-rs/run_actor.py
+++ b/ailets-rs/run_actor.py
@@ -90,12 +90,12 @@ class NodeRuntime:
     def n_of_streams(self, stream_name: str) -> int:
         return len(self._collect_streams("in", stream_name))
 
-    def open_read(self, stream_name: str, index: int) -> int:
+    def open_read(self, stream_name: str) -> int:
         specs = self._collect_streams("in", stream_name)
-        if index < 0 or index >= len(specs):
-            raise ValueError(f"No stream '{stream_name}' with index {index}")
+        if not specs:
+            raise ValueError(f"No input stream '{stream_name}'")
 
-        vof = specs[index].value_or_file
+        vof = specs[0].value_or_file
         if vof == "-":
             self.streams.append(sys.stdin.buffer)
         elif vof.startswith("@"):
@@ -209,9 +209,9 @@ def register_node_runtime(
         name = buf_to_str.get_string(name_ptr)
         return nr.n_of_streams(name)
 
-    def open_read(name_ptr: int, index: int) -> int:
+    def open_read(name_ptr: int) -> int:
         name = buf_to_str.get_string(name_ptr)
-        return nr.open_read(name, index)
+        return nr.open_read(name)
 
     def open_write(name_ptr: int) -> int:
         name = buf_to_str.get_string(name_ptr)

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -176,9 +176,6 @@ class INodeRuntime(Protocol):
     def get_next_name(self, base_name: str) -> str:
         raise NotImplementedError
 
-    async def read_dir(self, dir_name: str) -> Sequence[str]:
-        raise NotImplementedError
-
 
 @dataclass(frozen=True)
 class NodeDescFunc:

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -155,10 +155,7 @@ class INodeRuntime(Protocol):
     def get_name(self) -> str:
         raise NotImplementedError
 
-    def n_of_inputs(self, slot_name: str) -> int:
-        raise NotImplementedError
-
-    async def open_read(self, slot_name: str, index: int) -> int:
+    async def open_read(self, slot_name: str) -> int:
         raise NotImplementedError
 
     async def open_write(self, slot_name: str) -> int:

--- a/pylib-v1/ailets/cons/flow_builder.py
+++ b/pylib-v1/ailets/cons/flow_builder.py
@@ -81,7 +81,7 @@ async def prompt_to_dagops(
 
         n = env.seqno.next_seqno()
         b = os.path.basename(prompt_item.value)
-        file_key = env.dagops.get_next_name(f"media/{b}.{n}")
+        file_key = env.dagops.get_next_name(f"spool/{b}.{n}")
         mk_node(
             json.dumps(
                 {

--- a/pylib-v1/ailets/cons/input_reader.py
+++ b/pylib-v1/ailets/cons/input_reader.py
@@ -52,10 +52,10 @@ class MergeInputReader(IAsyncReader):
             self.current_reader = None
 
         pipes = _get_pipes(self.piper, self.deps, self.slot_name)
-        if self.index > len(pipes):
+        self.index += 1
+        if self.index >= len(pipes):
             self.closed = True
             return b""
 
-        self.index += 1
         self.current_reader = pipes[self.index].get_reader(self.read_handle)
         return await self.read(size)

--- a/pylib-v1/ailets/cons/input_reader.py
+++ b/pylib-v1/ailets/cons/input_reader.py
@@ -54,6 +54,15 @@ class MergeInputReader(IAsyncReader):
 
         pipes = _get_pipes(self.piper, self.deps, self.slot_name)
         self.index += 1
+
+        # Open an attachment from the kv
+        if not len(pipes) and self.index == 0 and "/" in self.slot_name:
+            try:
+                pipe = self.piper.get_existing_pipe("/", self.slot_name)
+                pipes = [pipe]
+            except KeyError:
+                pass
+
         if self.index >= len(pipes):
             self.closed = True
             return b""

--- a/pylib-v1/ailets/cons/input_reader.py
+++ b/pylib-v1/ailets/cons/input_reader.py
@@ -1,0 +1,61 @@
+from typing import Optional, Sequence
+
+from .atyping import Dependency, IAsyncReader, IPiper, IPipe
+
+
+def _get_pipes(
+    piper: IPiper, deps: Sequence[Dependency], slot_name: str
+) -> Sequence[IPipe]:
+    slot_deps = [dep for dep in deps if dep.name == slot_name]
+    pipes = []
+    for dep in slot_deps:
+        try:
+            pipe = piper.get_existing_pipe(dep.source, dep.slot)
+        except KeyError:
+            continue
+        pipes.append(pipe)
+    return pipes
+
+
+class MergeInputReader(IAsyncReader):
+    def __init__(
+        self,
+        piper: IPiper,
+        deps: Sequence[Dependency],
+        slot_name: str,
+        read_handle: int,
+    ):
+        self.piper = piper
+        self.deps = deps
+        self.slot_name = slot_name
+        self.read_handle = read_handle
+        self.index = -1
+        self.current_reader: Optional[IAsyncReader] = None
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def read(self, size: int) -> bytes:
+        if self.closed:
+            return b""
+
+        if self.current_reader is not None:
+            if self.current_reader.closed:
+                self.current_reader = None
+
+        if self.current_reader is not None:
+            bytes_read = await self.current_reader.read(size)
+            if len(bytes_read) > 0:
+                return bytes_read
+            self.current_reader.close()
+            self.current_reader = None
+
+        pipes = _get_pipes(self.piper, self.deps, self.slot_name)
+        if self.index > len(pipes):
+            self.closed = True
+            return b""
+
+        self.index += 1
+        self.current_reader = pipes[self.index].get_reader(self.read_handle)
+        return await self.read(size)

--- a/pylib-v1/ailets/cons/input_reader.py
+++ b/pylib-v1/ailets/cons/input_reader.py
@@ -80,7 +80,7 @@ async def iter_input_objects(
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Iterate over all slots. Each slot contains JSON objects,
     either as a JSON array or as individual objects without separation."""
-    fd = await runtime.open_read(slot_name, 0)
+    fd = await runtime.open_read(slot_name)
     buffer = await read_all(runtime, fd)
     await runtime.close(fd)
 

--- a/pylib-v1/ailets/cons/input_reader.py
+++ b/pylib-v1/ailets/cons/input_reader.py
@@ -80,58 +80,52 @@ async def iter_input_objects(
 ) -> AsyncGenerator[dict[str, Any], None]:
     """Iterate over all slots. Each slot contains JSON objects,
     either as a JSON array or as individual objects without separation."""
-    # `n_of_inputs` can change with time, therefore don't use `range`
-    i = 0
-    while i < runtime.n_of_inputs(slot_name):
-        i += 1
+    fd = await runtime.open_read(slot_name, 0)
+    buffer = await read_all(runtime, fd)
+    await runtime.close(fd)
 
-        fd = await runtime.open_read(slot_name, i - 1)
-        buffer = await read_all(runtime, fd)
-        await runtime.close(fd)
+    if len(buffer) == 0:
+        return
 
-        if len(buffer) == 0:
+    sbuf = buffer.decode("utf-8")
+
+    decoder = json.JSONDecoder()
+
+    pos = 0
+    while pos < len(sbuf):
+        #
+        # Skip whitespace and SSE tokens
+        #
+        while pos < len(sbuf) and sbuf[pos].isspace():
+            pos += 1
+        if pos >= len(sbuf):
+            break
+
+        skipped_sse_tokens = False
+        if sbuf[pos] != "{" and sbuf[pos] != "[":
+            for token in sse_tokens:
+                if sbuf[pos:].startswith(token):
+                    skipped_sse_tokens = True
+                    pos += len(token)
+                    break
+
+        if skipped_sse_tokens:
             continue
 
-        sbuf = buffer.decode("utf-8")
+        #
+        # Parse JSON object
+        #
+        try:
+            obj, obj_len = decoder.raw_decode(sbuf[pos:])
+            pos += obj_len
 
-        decoder = json.JSONDecoder()
+            if isinstance(obj, list):
+                for item in obj:
+                    yield item
+            else:
+                yield obj
 
-        pos = 0
-        while pos < len(sbuf):
-            #
-            # Skip whitespace and SSE tokens
-            #
-            while pos < len(sbuf) and sbuf[pos].isspace():
-                pos += 1
-            if pos >= len(sbuf):
-                break
-
-            skipped_sse_tokens = False
-            if sbuf[pos] != "{" and sbuf[pos] != "[":
-                for token in sse_tokens:
-                    if sbuf[pos:].startswith(token):
-                        skipped_sse_tokens = True
-                        pos += len(token)
-                        break
-
-            if skipped_sse_tokens:
-                continue
-
-            #
-            # Parse JSON object
-            #
-            try:
-                obj, obj_len = decoder.raw_decode(sbuf[pos:])
-                pos += obj_len
-
-                if isinstance(obj, list):
-                    for item in obj:
-                        yield item
-                else:
-                    yield obj
-
-            except json.JSONDecodeError:
-                raise ValueError(
-                    f"Failed to decode JSON at position {pos}: "
-                    f"{sbuf[pos:pos+20]!r}..."
-                )
+        except json.JSONDecodeError:
+            raise ValueError(
+                f"Failed to decode JSON at position {pos}: " f"{sbuf[pos:pos+20]!r}..."
+            )

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -41,7 +41,7 @@ class NodeRuntime(INodeRuntime):
     def get_name(self) -> str:
         return self.node_name
 
-    async def open_read(self, slot_name: str, index: int) -> int:
+    async def open_read(self, slot_name: str) -> int:
         fd = self.env.seqno.next_seqno()
 
         reader: IAsyncReader
@@ -52,7 +52,7 @@ class NodeRuntime(INodeRuntime):
             reader = MergeInputReader(self.piper, self.deps, slot_name, fd)
 
         self.open_fds[fd] = OpenFd(
-            debug_hint=f"{self.node_name}.{slot_name}[{index}]",
+            debug_hint=f"{self.node_name}.{slot_name}",
             reader=reader,
             writer=None,
         )

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -41,9 +41,6 @@ class NodeRuntime(INodeRuntime):
     def get_name(self) -> str:
         return self.node_name
 
-    def n_of_inputs(self, slot_name: str) -> int:
-        return 1
-
     async def open_read(self, slot_name: str, index: int) -> int:
         fd = self.env.seqno.next_seqno()
 

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -105,8 +105,5 @@ class NodeRuntime(INodeRuntime):
             self.cached_dagops = NodeDagops(self.env, self)
         return self.cached_dagops
 
-    async def read_dir(self, dir_name: str) -> Sequence[str]:
-        return self.env.kv.listdir(dir_name)
-
     def get_next_name(self, base_name: str) -> str:
         return self.env.dagops.get_next_name(base_name)

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -65,11 +65,7 @@ class NodeRuntime(INodeRuntime):
         return self.node_name
 
     def n_of_inputs(self, slot_name: str) -> int:
-        if slot_name == "env":
-            return 1
-        if slot_name == "log":
-            return 1
-        return len(self._get_pipes(slot_name))
+        return 1
 
     async def open_read(self, slot_name: str, index: int) -> int:
         pipes = self._get_pipes(slot_name)

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -38,9 +38,6 @@ def fill_wasm_import_object(
     buf_to_str: BufToStr,
     runtime: INodeRuntime,
 ) -> None:
-    def sync_n_of_inputs(name_ptr: int) -> int:
-        return 1
-
     async def open_read(name_ptr: int) -> int:
         name = buf_to_str.get_string(name_ptr)
         return await runtime.open_read(name)
@@ -151,7 +148,7 @@ def fill_wasm_import_object(
             )
             return -1
 
-    def sync_open_read(name_ptr: int, index: int) -> int:
+    def sync_open_read(name_ptr: int) -> int:
         return asyncio.run(open_read(name_ptr))
 
     def sync_open_write(name_ptr: int) -> int:
@@ -182,7 +179,6 @@ def fill_wasm_import_object(
     import_object.register(
         "",
         {
-            "n_of_streams": wasmer.Function(store, sync_n_of_inputs),
             "open_read": wasmer.Function(store, sync_open_read),
             "open_write": wasmer.Function(store, sync_open_write),
             "aread": wasmer.Function(store, sync_aread),

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -41,9 +41,9 @@ def fill_wasm_import_object(
     def sync_n_of_inputs(name_ptr: int) -> int:
         return 1
 
-    async def open_read(name_ptr: int, index: int) -> int:
+    async def open_read(name_ptr: int) -> int:
         name = buf_to_str.get_string(name_ptr)
-        return await runtime.open_read(name, index)
+        return await runtime.open_read(name)
 
     async def open_write(name_ptr: int) -> int:
         name = buf_to_str.get_string(name_ptr)
@@ -152,7 +152,7 @@ def fill_wasm_import_object(
             return -1
 
     def sync_open_read(name_ptr: int, index: int) -> int:
-        return asyncio.run(open_read(name_ptr, index))
+        return asyncio.run(open_read(name_ptr))
 
     def sync_open_write(name_ptr: int) -> int:
         return asyncio.run(open_write(name_ptr))

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -182,7 +182,7 @@ def fill_wasm_import_object(
     import_object.register(
         "",
         {
-            "n_of_inputs": wasmer.Function(store, sync_n_of_inputs),
+            "n_of_streams": wasmer.Function(store, sync_n_of_inputs),
             "open_read": wasmer.Function(store, sync_open_read),
             "open_write": wasmer.Function(store, sync_open_write),
             "aread": wasmer.Function(store, sync_aread),

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -38,9 +38,8 @@ def fill_wasm_import_object(
     buf_to_str: BufToStr,
     runtime: INodeRuntime,
 ) -> None:
-    async def n_of_inputs(name_ptr: int) -> int:
-        name = buf_to_str.get_string(name_ptr)
-        return runtime.n_of_inputs(name)
+    def sync_n_of_inputs(name_ptr: int) -> int:
+        return 1
 
     async def open_read(name_ptr: int, index: int) -> int:
         name = buf_to_str.get_string(name_ptr)
@@ -152,9 +151,6 @@ def fill_wasm_import_object(
             )
             return -1
 
-    def sync_n_of_inputs(name_ptr: int) -> int:
-        return asyncio.run(n_of_inputs(name_ptr))
-
     def sync_open_read(name_ptr: int, index: int) -> int:
         return asyncio.run(open_read(name_ptr, index))
 
@@ -186,7 +182,7 @@ def fill_wasm_import_object(
     import_object.register(
         "",
         {
-            "n_of_streams": wasmer.Function(store, sync_n_of_inputs),
+            "n_of_inputs": wasmer.Function(store, sync_n_of_inputs),
             "open_read": wasmer.Function(store, sync_open_read),
             "open_write": wasmer.Function(store, sync_open_write),
             "aread": wasmer.Function(store, sync_aread),

--- a/pylib-v1/ailets/cons/util.py
+++ b/pylib-v1/ailets/cons/util.py
@@ -1,5 +1,6 @@
-import json
-from typing import Any, AsyncGenerator, Dict, Literal, Sequence
+from typing import Any, Dict, Literal
+
+from ailets.cons.input_reader import iter_input_objects
 from .atyping import INodeRuntime
 
 
@@ -17,86 +18,11 @@ def to_basename(name: str) -> str:
     return name
 
 
-async def read_all(runtime: INodeRuntime, fd: int) -> bytes:
-    buffer = bytearray(1024)
-    result = bytearray()
-    while True:
-        count = await runtime.read(fd, buffer, len(buffer))
-        if count == 0:
-            break
-        result.extend(buffer[:count])
-    return bytes(result)
-
-
 async def write_all(runtime: INodeRuntime, fd: int, data: bytes) -> None:
     pos = 0
     while pos < len(data):
         count = await runtime.write(fd, data[pos:], len(data) - pos)
         pos += count
-
-
-async def iter_input_objects(
-    runtime: INodeRuntime,
-    slot_name: str,
-    sse_tokens: Sequence[str] = (),
-) -> AsyncGenerator[dict[str, Any], None]:
-    """Iterate over all slots. Each slot contains JSON objects,
-    either as a JSON array or as individual objects without separation."""
-    # `n_of_inputs` can change with time, therefore don't use `range`
-    i = 0
-    while i < runtime.n_of_inputs(slot_name):
-        i += 1
-
-        fd = await runtime.open_read(slot_name, i - 1)
-        buffer = await read_all(runtime, fd)
-        await runtime.close(fd)
-
-        if len(buffer) == 0:
-            continue
-
-        sbuf = buffer.decode("utf-8")
-
-        decoder = json.JSONDecoder()
-
-        pos = 0
-        while pos < len(sbuf):
-            #
-            # Skip whitespace and SSE tokens
-            #
-            while pos < len(sbuf) and sbuf[pos].isspace():
-                pos += 1
-            if pos >= len(sbuf):
-                break
-
-            skipped_sse_tokens = False
-            if sbuf[pos] != "{" and sbuf[pos] != "[":
-                for token in sse_tokens:
-                    if sbuf[pos:].startswith(token):
-                        skipped_sse_tokens = True
-                        pos += len(token)
-                        break
-
-            if skipped_sse_tokens:
-                continue
-
-            #
-            # Parse JSON object
-            #
-            try:
-                obj, obj_len = decoder.raw_decode(sbuf[pos:])
-                pos += obj_len
-
-                if isinstance(obj, list):
-                    for item in obj:
-                        yield item
-                else:
-                    yield obj
-
-            except json.JSONDecodeError:
-                raise ValueError(
-                    f"Failed to decode JSON at position {pos}: "
-                    f"{sbuf[pos:pos+20]!r}..."
-                )
 
 
 async def read_env_pipe(runtime: INodeRuntime) -> Dict[str, Any]:

--- a/pylib-v1/ailets/models/dalle/messages_to_query.py
+++ b/pylib-v1/ailets/models/dalle/messages_to_query.py
@@ -88,9 +88,6 @@ class ExtractedPrompt(TypedDict):
 
 
 async def read_from_slot(runtime: INodeRuntime, slot_name: str) -> bytes:
-    n = runtime.n_of_inputs(slot_name)
-    assert n == 1, f"Expected exactly one input for {slot_name}, got {n}"
-
     fd = await runtime.open_read(slot_name, 0)
     content = await read_all(runtime, fd)
     await runtime.close(fd)

--- a/pylib-v1/ailets/models/dalle/messages_to_query.py
+++ b/pylib-v1/ailets/models/dalle/messages_to_query.py
@@ -43,7 +43,7 @@ def task_to_headers(task: str) -> dict[str, str]:
 
 
 async def copy_image_to_fd(runtime: INodeRuntime, key: str, fd: int) -> None:
-    fd_in = await runtime.open_read(key, 0)
+    fd_in = await runtime.open_read(key)
     buffer = await read_all(runtime, fd_in)
     await runtime.close(fd_in)
     await write_all(runtime, fd, buffer)
@@ -88,7 +88,7 @@ class ExtractedPrompt(TypedDict):
 
 
 async def read_from_slot(runtime: INodeRuntime, slot_name: str) -> bytes:
-    fd = await runtime.open_read(slot_name, 0)
+    fd = await runtime.open_read(slot_name)
     content = await read_all(runtime, fd)
     await runtime.close(fd)
     return content

--- a/pylib-v1/ailets/models/dalle/messages_to_query.py
+++ b/pylib-v1/ailets/models/dalle/messages_to_query.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Optional, Sequence, TypedDict, Union
+from ailets.cons.input_reader import iter_input_objects
 from ailets.cons.typeguards import (
     is_content_item_image,
     is_content_item_text,
@@ -10,12 +11,12 @@ from ailets.cons.atyping import (
     INodeRuntime,
 )
 from ailets.cons.util import (
-    iter_input_objects,
     log,
-    read_all,
     read_env_pipe,
     write_all,
 )
+from ailets.cons.input_reader import read_all
+
 
 # https://platform.openai.com/docs/api-reference/images/create
 

--- a/pylib-v1/ailets/models/dalle/messages_to_query.py
+++ b/pylib-v1/ailets/models/dalle/messages_to_query.py
@@ -56,7 +56,7 @@ async def to_binary_body_in_kv(
         body = body.copy()
         del body["prompt"]
 
-    body_key = runtime.get_next_name("query_body")
+    body_key = runtime.get_next_name("spool/query_body")
     fd = await runtime.open_write(body_key)
 
     for key, value in body.items():

--- a/pylib-v1/ailets/models/dalle/response_to_messages.py
+++ b/pylib-v1/ailets/models/dalle/response_to_messages.py
@@ -7,7 +7,8 @@ from ailets.cons.atyping import (
     Content,
     INodeRuntime,
 )
-from ailets.cons.util import iter_input_objects, write_all
+from ailets.cons.input_reader import iter_input_objects
+from ailets.cons.util import write_all
 
 
 async def response_to_messages(runtime: INodeRuntime) -> None:

--- a/pylib-v1/ailets/models/gpt4o/messages_to_query.py
+++ b/pylib-v1/ailets/models/gpt4o/messages_to_query.py
@@ -38,7 +38,7 @@ async def rewrite_content_item(
     key = item.get("key")
     assert key, "Image URL or key is required"
 
-    fd = await runtime.open_read(key, 0)
+    fd = await runtime.open_read(key)
     data = await read_all(runtime, fd)
     await runtime.close(fd)
 

--- a/pylib-v1/ailets/models/gpt4o/messages_to_query.py
+++ b/pylib-v1/ailets/models/gpt4o/messages_to_query.py
@@ -7,7 +7,8 @@ from ailets.cons.atyping import (
     ContentItemFunction,
     INodeRuntime,
 )
-from ailets.cons.util import iter_input_objects, read_all, write_all
+from ailets.cons.input_reader import iter_input_objects, read_all
+from ailets.cons.util import write_all
 from ailets.models.gpt4o.lib.typing import Gpt4oContentItem, Gpt4oMessage
 
 url = "https://api.openai.com/v1/chat/completions"

--- a/pylib-v1/ailets/stdlib/messages_to_markdown.py
+++ b/pylib-v1/ailets/stdlib/messages_to_markdown.py
@@ -7,7 +7,8 @@ from ailets.cons.atyping import (
     ContentItemImage,
     INodeRuntime,
 )
-from ailets.cons.util import iter_input_objects, write_all
+from ailets.cons.util import write_all
+from ailets.cons.input_reader import iter_input_objects
 
 need_separator = False
 

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -1,7 +1,8 @@
 import json
 from typing import Any, Dict
 from ailets.cons.atyping import INodeRuntime
-from ailets.cons.util import iter_input_objects, write_all
+from ailets.cons.util import write_all
+from ailets.cons.input_reader import iter_input_objects
 
 
 async def prompt_to_messages(runtime: INodeRuntime) -> None:

--- a/pylib-v1/ailets/stdlib/query.py
+++ b/pylib-v1/ailets/stdlib/query.py
@@ -37,7 +37,6 @@ async def query(runtime: INodeRuntime) -> None:
     if _run_count > MAX_RUNS:
         raise RuntimeError(f"Exceeded maximum number of runs ({MAX_RUNS})")
 
-    assert runtime.n_of_inputs("") == 1, "Expected exactly one query params dict"
     fd = await runtime.open_read("", 0)
     params = json.loads((await read_all(runtime, fd)).decode("utf-8"))
     await runtime.close(fd)
@@ -51,8 +50,6 @@ async def query(runtime: INodeRuntime) -> None:
             body_kwargs = {"json": params["body"]}
         elif "body_key" in params:
             key = params["body_key"]
-            n_inputs = runtime.n_of_inputs(key)
-            assert n_inputs == 1, f"Expected exactly one input '{key}', got {n_inputs}"
             fd = await runtime.open_read(key, 0)
             data = await read_all(runtime, fd)
             await runtime.close(fd)

--- a/pylib-v1/ailets/stdlib/query.py
+++ b/pylib-v1/ailets/stdlib/query.py
@@ -37,7 +37,7 @@ async def query(runtime: INodeRuntime) -> None:
     if _run_count > MAX_RUNS:
         raise RuntimeError(f"Exceeded maximum number of runs ({MAX_RUNS})")
 
-    fd = await runtime.open_read("", 0)
+    fd = await runtime.open_read("")
     params = json.loads((await read_all(runtime, fd)).decode("utf-8"))
     await runtime.close(fd)
 
@@ -50,7 +50,7 @@ async def query(runtime: INodeRuntime) -> None:
             body_kwargs = {"json": params["body"]}
         elif "body_key" in params:
             key = params["body_key"]
-            fd = await runtime.open_read(key, 0)
+            fd = await runtime.open_read(key)
             data = await read_all(runtime, fd)
             await runtime.close(fd)
             body_kwargs = {"data": data}

--- a/pylib-v1/ailets/stdlib/query.py
+++ b/pylib-v1/ailets/stdlib/query.py
@@ -3,7 +3,9 @@ import aiohttp
 import os
 import re
 from ailets.cons.atyping import INodeRuntime
-from ailets.cons.util import read_all, write_all
+from ailets.cons.util import write_all
+from ailets.cons.input_reader import read_all
+
 
 MAX_RUNS = 3  # Maximum number of runs allowed
 _run_count = 0  # Track number of runs

--- a/pylib-v1/ailets/stdlib/stdout.py
+++ b/pylib-v1/ailets/stdlib/stdout.py
@@ -6,21 +6,12 @@ async def stdout(runtime: INodeRuntime) -> None:
     """Print each value to stdout and return them unchanged."""
 
     buffer = bytearray(1024)
-    div = ""
-
-    for i in range(runtime.n_of_inputs("")):
-        fd = await runtime.open_read("", i)
-        while True:
-            count = await runtime.read(fd, buffer, len(buffer))
-            if count == 0:
-                break
-            if div:
-                print(div, end="")
-                div = ""
-            print(buffer[:count].decode("utf-8"), end="", flush=True)
-        await runtime.close(fd)
-
-        div = "\n"
+    fd = await runtime.open_read("", 0)
+    while True:
+        count = await runtime.read(fd, buffer, len(buffer))
+        if count == 0:
+            break
+        print(buffer[:count].decode("utf-8"), end="", flush=True)
 
     fd = await runtime.open_write("")
     await write_all(runtime, fd, "ok".encode("utf-8"))

--- a/pylib-v1/ailets/stdlib/stdout.py
+++ b/pylib-v1/ailets/stdlib/stdout.py
@@ -6,7 +6,7 @@ async def stdout(runtime: INodeRuntime) -> None:
     """Print each value to stdout and return them unchanged."""
 
     buffer = bytearray(1024)
-    fd = await runtime.open_read("", 0)
+    fd = await runtime.open_read("")
     while True:
         count = await runtime.read(fd, buffer, len(buffer))
         if count == 0:

--- a/pylib-v1/ailets/stdlib/toolcall_to_messages.py
+++ b/pylib-v1/ailets/stdlib/toolcall_to_messages.py
@@ -1,6 +1,7 @@
 import json
 from ..cons.atyping import ChatMessageTool, ContentItemFunction, INodeRuntime
-from ..cons.util import read_all, write_all
+from ..cons.util import write_all
+from ..cons.input_reader import read_all
 
 
 async def toolcall_to_messages(runtime: INodeRuntime) -> None:

--- a/pylib-v1/ailets/stdlib/toolcall_to_messages.py
+++ b/pylib-v1/ailets/stdlib/toolcall_to_messages.py
@@ -14,13 +14,6 @@ async def toolcall_to_messages(runtime: INodeRuntime) -> None:
     Writes:
         A single message in OpenAI chat format
     """
-    n_tool_results = runtime.n_of_inputs("")
-    assert (
-        n_tool_results == 1
-    ), f"Expected exactly one tool result, got {n_tool_results}"
-    n_specs = runtime.n_of_inputs("llm_tool_spec")
-    assert n_specs == 1, f"Expected exactly one tool spec, got {n_specs}"
-
     fd = await runtime.open_read("", 0)
     tool_result = (await read_all(runtime, fd)).decode("utf-8")
     await runtime.close(fd)

--- a/pylib-v1/ailets/stdlib/toolcall_to_messages.py
+++ b/pylib-v1/ailets/stdlib/toolcall_to_messages.py
@@ -14,11 +14,11 @@ async def toolcall_to_messages(runtime: INodeRuntime) -> None:
     Writes:
         A single message in OpenAI chat format
     """
-    fd = await runtime.open_read("", 0)
+    fd = await runtime.open_read("")
     tool_result = (await read_all(runtime, fd)).decode("utf-8")
     await runtime.close(fd)
 
-    fd = await runtime.open_read("llm_tool_spec", 0)
+    fd = await runtime.open_read("llm_tool_spec")
     spec: ContentItemFunction = json.loads(
         (await read_all(runtime, fd)).decode("utf-8")
     )


### PR DESCRIPTION
- Input stream merging is the task of the pylib now instead of the Rust AReader
- If slot name contains "/", open it from the kv if needed
- Use "spool" pseudodir for attachments in kv
- Move read functions from "utils" to "input_reader"

close #132 