### PR TITLE
A133 graceful shutdown on actor error

### DIFF
--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -20,6 +20,11 @@ from ailets.cons.notification_queue import INotificationQueue
 from ailets.cons.seqno import Seqno
 
 
+class Errors(IntEnum):
+    Unknown = -1
+    NoError = 0
+
+
 class IAsyncReader(Protocol):
     closed: bool
 
@@ -294,6 +299,12 @@ class IEnvironment(Protocol):
     nodereg: INodeRegistry
     processes: IProcesses
     notification_queue: INotificationQueue
+
+    def get_errno(self) -> Errors:
+        raise NotImplementedError
+
+    def set_errno(self, errno: Errors) -> None:
+        raise NotImplementedError
 
 
 #

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -38,6 +38,7 @@ class IAsyncReader(Protocol):
 
 class IAsyncWriter(Protocol):
     closed: bool
+    errno: int
 
     async def write(self, data: bytes) -> int:
         raise NotImplementedError

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -286,7 +286,7 @@ class IProcesses(Protocol):
     def is_node_active(self, name: str) -> bool:
         raise NotImplementedError
 
-    def add_value_node(self, name: str) -> None:
+    def add_finished_node(self, name: str) -> None:
         raise NotImplementedError
 
 

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -289,6 +289,12 @@ class IProcesses(Protocol):
     def add_finished_node(self, name: str) -> None:
         raise NotImplementedError
 
+    def set_completion_code(self, name: str, ccode: Errors) -> None:
+        raise NotImplementedError
+
+    def get_optional_completion_code(self, name: str) -> Optional[Errors]:
+        raise NotImplementedError
+
 
 class IEnvironment(Protocol):
     for_env_pipe: Dict[str, Any]

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -20,12 +20,6 @@ from ailets.cons.notification_queue import INotificationQueue
 from ailets.cons.seqno import Seqno
 
 
-class Errors(IntEnum):
-    Unknown = -1
-    NoError = 0
-    BrokenPipe = 1
-
-
 class IAsyncReader(Protocol):
     closed: bool
 
@@ -299,10 +293,10 @@ class IProcesses(Protocol):
     def add_finished_node(self, name: str) -> None:
         raise NotImplementedError
 
-    def set_completion_code(self, name: str, ccode: Errors) -> None:
+    def set_completion_code(self, name: str, ccode: int) -> None:
         raise NotImplementedError
 
-    def get_optional_completion_code(self, name: str) -> Optional[Errors]:
+    def get_optional_completion_code(self, name: str) -> Optional[int]:
         raise NotImplementedError
 
 
@@ -316,10 +310,10 @@ class IEnvironment(Protocol):
     processes: IProcesses
     notification_queue: INotificationQueue
 
-    def get_errno(self) -> Errors:
+    def get_errno(self) -> int:
         raise NotImplementedError
 
-    def set_errno(self, errno: Errors) -> None:
+    def set_errno(self, errno: int) -> None:
         raise NotImplementedError
 
 

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -23,6 +23,7 @@ from ailets.cons.seqno import Seqno
 class Errors(IntEnum):
     Unknown = -1
     NoError = 0
+    BrokenPipe = 1
 
 
 class IAsyncReader(Protocol):
@@ -45,6 +46,9 @@ class IAsyncWriter(Protocol):
         raise NotImplementedError
 
     def tell(self) -> int:
+        raise NotImplementedError
+
+    def set_error(self, errno: int) -> None:
         raise NotImplementedError
 
 

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -35,10 +35,12 @@ class IAsyncReader(Protocol):
     def close(self) -> None:
         raise NotImplementedError
 
+    def set_error(self, errno: int) -> None:
+        raise NotImplementedError
+
 
 class IAsyncWriter(Protocol):
     closed: bool
-    errno: int
 
     async def write(self, data: bytes) -> int:
         raise NotImplementedError
@@ -47,6 +49,9 @@ class IAsyncWriter(Protocol):
         raise NotImplementedError
 
     def tell(self) -> int:
+        raise NotImplementedError
+
+    def get_error(self) -> int:
         raise NotImplementedError
 
     def set_error(self, errno: int) -> None:

--- a/pylib-v1/ailets/cons/dagops.py
+++ b/pylib-v1/ailets/cons/dagops.py
@@ -133,7 +133,7 @@ class Dagops(IDagops):
         ), "Internal error: MemPipeWriter is expected"
         writer.write_sync(value)
         writer.close()
-        processes.add_value_node(full_name)
+        processes.add_finished_node(full_name)
 
         return node
 

--- a/pylib-v1/ailets/cons/dump.py
+++ b/pylib-v1/ailets/cons/dump.py
@@ -249,7 +249,10 @@ def print_dependency_tree(
         visited = set()
 
     node = dagops.get_node(node_name)
-    if node_name.startswith("defunc."):
+    errno = processes.get_optional_completion_code(node_name)
+    if errno is not None:
+        status = f"\033[31merrno: {errno}/{errno.name}\033[0m"
+    elif node_name.startswith("defunc."):
         status = "\033[90mdefunc\033[0m"
     else:
         status = (

--- a/pylib-v1/ailets/cons/dump.py
+++ b/pylib-v1/ailets/cons/dump.py
@@ -106,7 +106,7 @@ async def dump_pipe(path: str, pipe: IPipe, f: TextIO) -> None:
         {
             "pipe": path,
             "is_closed": writer.closed,
-            **({"errno": writer.errno} if writer.errno != 0 else {}),
+            **({"errno": writer.get_error()} if writer.get_error() != 0 else {}),
         },
         f,
         indent=2,

--- a/pylib-v1/ailets/cons/dump.py
+++ b/pylib-v1/ailets/cons/dump.py
@@ -255,7 +255,7 @@ def print_dependency_tree(
 
     node = dagops.get_node(node_name)
     errno = processes.get_optional_completion_code(node_name)
-    if errno is not None:
+    if errno is not None and errno != Errors.NoError:
         status = f"\033[31merrno: {errno}/{errno.name}\033[0m"
     elif node_name.startswith("defunc."):
         status = "\033[90mdefunc\033[0m"

--- a/pylib-v1/ailets/cons/dump.py
+++ b/pylib-v1/ailets/cons/dump.py
@@ -197,7 +197,7 @@ async def load_environment(f: TextIO, nodereg: INodeRegistry) -> Environment:
                 node = load_node(obj_data, nodereg, env.seqno)
                 env.dagops.nodes[node.name] = node
                 if obj_data.get("is_finished", False):
-                    env.processes.add_value_node(node.name)
+                    env.processes.add_finished_node(node.name)
             elif "path" in obj_data:
                 await load_kv_item(env.kv, obj_data)
             elif "pipe" in obj_data:

--- a/pylib-v1/ailets/cons/dump.py
+++ b/pylib-v1/ailets/cons/dump.py
@@ -106,6 +106,7 @@ async def dump_pipe(path: str, pipe: IPipe, f: TextIO) -> None:
         {
             "pipe": path,
             "is_closed": writer.closed,
+            **({"errno": writer.errno} if writer.errno != 0 else {}),
         },
         f,
         indent=2,
@@ -115,7 +116,11 @@ async def dump_pipe(path: str, pipe: IPipe, f: TextIO) -> None:
 async def load_pipe(piper: IPiper, data: dict[str, Any]) -> None:
     path = data["pipe"]
     is_closed = data.get("is_closed", False)
+    errno = data.get("errno", 0)
     pipe = piper.create_pipe(path, "", open_mode="append")
+    if errno != 0:
+        writer = pipe.get_writer()
+        writer.set_error(errno)
     if is_closed:
         writer = pipe.get_writer()
         writer.close()

--- a/pylib-v1/ailets/cons/environment.py
+++ b/pylib-v1/ailets/cons/environment.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict
-from ailets.cons.atyping import IEnvironment, INodeRegistry
+from ailets.cons.atyping import IEnvironment, INodeRegistry, Errors
 from ailets.cons.dagops import Dagops
 from ailets.cons.notification_queue import NotificationQueue
 from ailets.cons.processes import Processes
@@ -11,6 +11,8 @@ from ailets.cons.memkv import MemKV
 class Environment(IEnvironment):
     def __init__(self, nodereg: INodeRegistry) -> None:
         self.for_env_pipe: Dict[str, Any] = {}
+        self.errno: Errors = Errors.NoError
+
         self.seqno = Seqno()
         self.kv = MemKV()
         self.dagops = Dagops(self.seqno)
@@ -22,3 +24,9 @@ class Environment(IEnvironment):
     def destroy(self) -> None:
         self.processes.destroy()
         self.piper.destroy()
+
+    def get_errno(self) -> Errors:
+        return self.errno
+
+    def set_errno(self, errno: Errors) -> None:
+        self.errno = errno

--- a/pylib-v1/ailets/cons/environment.py
+++ b/pylib-v1/ailets/cons/environment.py
@@ -1,5 +1,5 @@
 from typing import Any, Dict
-from ailets.cons.atyping import IEnvironment, INodeRegistry, Errors
+from ailets.cons.atyping import IEnvironment, INodeRegistry
 from ailets.cons.dagops import Dagops
 from ailets.cons.notification_queue import NotificationQueue
 from ailets.cons.processes import Processes
@@ -11,7 +11,7 @@ from ailets.cons.memkv import MemKV
 class Environment(IEnvironment):
     def __init__(self, nodereg: INodeRegistry) -> None:
         self.for_env_pipe: Dict[str, Any] = {}
-        self.errno: Errors = Errors.NoError
+        self.errno: int = 0
 
         self.seqno = Seqno()
         for _ in range(10):  # To avoid collision with StdHandles
@@ -28,8 +28,8 @@ class Environment(IEnvironment):
         self.processes.destroy()
         self.piper.destroy()
 
-    def get_errno(self) -> Errors:
+    def get_errno(self) -> int:
         return self.errno
 
-    def set_errno(self, errno: Errors) -> None:
+    def set_errno(self, errno: int) -> None:
         self.errno = errno

--- a/pylib-v1/ailets/cons/environment.py
+++ b/pylib-v1/ailets/cons/environment.py
@@ -14,6 +14,9 @@ class Environment(IEnvironment):
         self.errno: Errors = Errors.NoError
 
         self.seqno = Seqno()
+        for _ in range(10):  # To avoid collision with StdHandles
+            self.seqno.next_seqno()
+
         self.kv = MemKV()
         self.dagops = Dagops(self.seqno)
         self.notification_queue = NotificationQueue()

--- a/pylib-v1/ailets/cons/mempipe.py
+++ b/pylib-v1/ailets/cons/mempipe.py
@@ -126,10 +126,12 @@ class Reader(IAsyncReader):
         lock = self.writer.queue.get_lock()
         with lock:
             if self._should_wait_with_autoclose():
-                await self.writer.queue.wait_unsafe(
-                    self.writer.handle, f"MemPipe.Reader {self.handle}"
-                )
-                lock.acquire()
+                try:
+                    await self.writer.queue.wait_unsafe(
+                        self.writer.handle, f"MemPipe.Reader {self.handle}"
+                    )
+                finally:
+                    lock.acquire()
 
 
 class MemPipe:

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -61,6 +61,10 @@ class NodeRuntime(INodeRuntime):
     async def destroy(self) -> None:
         fds = list(self.open_fds.keys())
         for fd in fds:
+            if self.errno != Errors.NoError:
+                writer = self.open_fds[fd].writer
+                if writer is not None and not writer.closed:
+                    writer.set_error(int(Errors.BrokenPipe))
             await self.close(fd)
             del self.open_fds[fd]
 

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -61,6 +61,9 @@ class NodeRuntime(INodeRuntime):
         fds = list(self.open_fds.keys())
         for fd in fds:
             if self.errno != 0:
+                reader = self.open_fds[fd].reader
+                if reader is not None and not reader.closed:
+                    reader.set_error(self.errno)
                 writer = self.open_fds[fd].writer
                 if writer is not None and not writer.closed:
                     writer.set_error(self.errno)

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+import errno
 import sys
 from typing import Dict, Optional, Sequence
 
@@ -64,7 +65,7 @@ class NodeRuntime(INodeRuntime):
             if self.errno != Errors.NoError:
                 writer = self.open_fds[fd].writer
                 if writer is not None and not writer.closed:
-                    writer.set_error(int(Errors.BrokenPipe))
+                    writer.set_error(errno.EPIPE)
             await self.close(fd)
             del self.open_fds[fd]
 

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -17,6 +17,7 @@ from .atyping import (
     INodeRuntime,
     IPipe,
     StdHandles,
+    Errors,
 )
 
 
@@ -55,6 +56,7 @@ class NodeRuntime(INodeRuntime):
             StdHandles.metrics: Opener.print,
             StdHandles.trace: Opener.print,
         }
+        self.errno: Errors = Errors.NoError
 
     async def destroy(self) -> None:
         fds = list(self.open_fds.keys())
@@ -64,6 +66,12 @@ class NodeRuntime(INodeRuntime):
 
     def get_name(self) -> str:
         return self.node_name
+
+    def get_errno(self) -> Errors:
+        return self.errno
+
+    def set_errno(self, errno: Errors) -> None:
+        self.errno = errno
 
     async def auto_open(self, fd: StdHandles) -> None:
         opener = self.fd_openers[fd]

--- a/pylib-v1/ailets/cons/notification_queue.py
+++ b/pylib-v1/ailets/cons/notification_queue.py
@@ -37,8 +37,11 @@ if should_wait():
 lock = queue.get_lock()
 with lock:
     if should_wait():
-        queue.wait_unsafe(handle, debug_hint)
-        lock.acquire()  # re-aquire the lock to match the release in `wait_for_handle`
+        try:
+            queue.wait_unsafe(handle, debug_hint)
+        finally:  # expect `CancelledError` eventually
+            # re-aquire the lock to match the release in `wait_for_handle`
+            lock.acquire()
 ```
 
 2) Subscribing to a handle

--- a/pylib-v1/ailets/cons/piper.py
+++ b/pylib-v1/ailets/cons/piper.py
@@ -49,6 +49,10 @@ class PrintWrapper(IPipe):
             # stream for which the app has own ownership.
             self.closed = True
 
+        def set_error(self, errno: int) -> None:
+            if self.writer is not None:
+                self.writer.set_error(errno)
+
         def __str__(self) -> str:
             return (
                 f"PrintWrapper.Writer(output={self.output}, "

--- a/pylib-v1/ailets/cons/piper.py
+++ b/pylib-v1/ailets/cons/piper.py
@@ -50,6 +50,11 @@ class PrintWrapper(IPipe):
             # stream for which the app has own ownership.
             self.closed = True
 
+        def get_error(self) -> int:
+            if self.writer is not None:
+                return self.writer.get_error()
+            return self.errno
+
         def set_error(self, errno: int) -> None:
             self.errno = errno
             if self.writer is not None:

--- a/pylib-v1/ailets/cons/piper.py
+++ b/pylib-v1/ailets/cons/piper.py
@@ -28,6 +28,7 @@ class PrintWrapper(IPipe):
             self.output = output
             self.writer = writer
             self.closed = False
+            self.errno = 0
 
         async def write(self, data: bytes) -> int:
             self.output.write(data.decode("utf-8"))
@@ -50,13 +51,15 @@ class PrintWrapper(IPipe):
             self.closed = True
 
         def set_error(self, errno: int) -> None:
+            self.errno = errno
             if self.writer is not None:
                 self.writer.set_error(errno)
 
         def __str__(self) -> str:
             return (
                 f"PrintWrapper.Writer(output={self.output}, "
-                f"closed={self.closed}, writer={self.writer})"
+                f"closed={self.closed}, writer={self.writer}, "
+                f"errno={self.errno})"
             )
 
     def __init__(self, output: IO[str], pipe: Optional[IPipe]) -> None:

--- a/pylib-v1/ailets/cons/piper.py
+++ b/pylib-v1/ailets/cons/piper.py
@@ -109,6 +109,7 @@ class Piper(IPiper):
     def init_fsops_handle(self) -> None:
         self.fsops_handle = self.seqno.next_seqno()
         self.queue.whitelist(self.fsops_handle, "Piper: file system operations")
+        logger.debug("Piper: fsops_handle is: %s", self.fsops_handle)
 
     def get_fsops_handle(self) -> int:
         return self.fsops_handle

--- a/pylib-v1/ailets/cons/plugin.py
+++ b/pylib-v1/ailets/cons/plugin.py
@@ -142,8 +142,6 @@ def hijack_msg2query(nodereg: NodeRegistry, wasm_registry: IWasmRegistry) -> Non
         nodereg,
         wasm_registry,
         ".gpt4o.messages_to_query",
-        # "process_query",
-        # "messages_to_query.wasm",
-        "execute",
-        "cat.wasm",
+        "process_query",
+        "messages_to_query.wasm",
     )

--- a/pylib-v1/ailets/cons/plugin.py
+++ b/pylib-v1/ailets/cons/plugin.py
@@ -142,6 +142,8 @@ def hijack_msg2query(nodereg: NodeRegistry, wasm_registry: IWasmRegistry) -> Non
         nodereg,
         wasm_registry,
         ".gpt4o.messages_to_query",
-        "process_query",
-        "messages_to_query.wasm",
+        # "process_query",
+        # "messages_to_query.wasm",
+        "execute",
+        "cat.wasm",
     )

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -238,15 +238,15 @@ class Processes(IProcesses):
             self.active_nodes.add(name)
             await node.func(node_runtime)
             self.finished_nodes.add(name)
-        except Exception:
-            exc = sys.exc_info()[1]
-            print(f"Error building node '{name}'")
-            print(f"Function: {node.func.__name__}")
-            print("Dependencies:")
-            for dep in self.deps[name]:
-                print(f"  {dep.source} ({dep.slot}) -> {dep.name}")
-            print(f"Exception: {exc}")
-            raise
+        except Exception as exc:
+            print(f"*** ailet error: {name}: {str(exc)}", file=sys.stderr)
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f"Error building node '{name}'")
+                logger.debug(f"Function: {node.func.__name__}")
+                logger.debug("Dependencies:")
+                for dep in self.deps[name]:
+                    logger.debug(f"  {dep.source} ({dep.slot}) -> {dep.name}")
+                logger.debug(f"Exception: {exc}")
         finally:
             await node_runtime.destroy()
             self.queue.notify(self.progress_handle, -1)

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -40,6 +40,8 @@ class Processes(IProcesses):
 
         self.progress_handle: int = env.seqno.next_seqno()
         self.queue.whitelist(self.progress_handle, "ailets.processes")
+        logger.debug("Processes: progress_handle is: %s", self.progress_handle)
+
         self.pool: set[asyncio.Task[None]] = set()
         self.loop = asyncio.get_event_loop()
 

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -85,7 +85,7 @@ class Processes(IProcesses):
     def is_node_active(self, name: str) -> bool:
         return name in self.active_nodes
 
-    def add_value_node(self, name: str) -> None:
+    def add_finished_node(self, name: str) -> None:
         self.finished_nodes.add(name)
 
     def resolve_deps(self) -> None:

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -21,6 +21,10 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
         keys,
     )
 
+    # FIXME
+    if "FIXME" in json.dumps(list(messages)):
+        raise RuntimeError("FIXME to see error handling in action")
+
     await write_all(
         runtime,
         StdHandles.stdout,

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, Dict
 from ailets.cons.atyping import INodeRuntime, StdHandles
@@ -20,6 +21,26 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
         },
         keys,
     )
+    # FIXME
+    if "FIXME" in json.dumps(list(messages)):
+        await write_all(
+            runtime,
+            StdHandles.stdout,
+            "(AAAAAAAAAAAAA)\n".encode("utf-8"),
+        )
+        await asyncio.sleep(0.1)
+        await write_all(
+            runtime,
+            StdHandles.stdout,
+            "(BBBBBBBBBBBBB)\n".encode("utf-8"),
+        )
+        await asyncio.sleep(0.1)
+        await write_all(
+            runtime,
+            StdHandles.stdout,
+            "(CCCCCCCCCCCCC)\n".encode("utf-8"),
+        )
+        raise RuntimeError("FIXME to see error handling in action")
 
     await write_all(
         runtime,

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -21,12 +21,12 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
         keys,
     )
 
-    # FIXME
-    if "FIXME" in json.dumps(list(messages)):
-        raise RuntimeError("FIXME to see error handling in action")
-
     await write_all(
         runtime,
         StdHandles.stdout,
         json.dumps(list(messages)).encode("utf-8"),
     )
+
+    # FIXME
+    if "FIXME" in json.dumps(list(messages)):
+        raise RuntimeError("FIXME to see error handling in action")

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -14,40 +14,38 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
 
     keys = list(role_to_content.keys())
     keys.sort()
-    messages = map(
-        lambda key: {
-            "role": key,
-            "content": role_to_content[key],
-        },
-        keys,
+    messages = list(
+        map(
+            lambda key: {
+                "role": key,
+                "content": role_to_content[key],
+            },
+            keys,
+        )
     )
     # FIXME
     if "FIXME" in json.dumps(list(messages)):
+        for i in range(3):
+            await write_all(
+                runtime,
+                StdHandles.stdout,
+                json.dumps(messages).encode("utf-8"),
+            )
+            await asyncio.sleep(0.1)
         await write_all(
             runtime,
             StdHandles.stdout,
-            "(AAAAAAAAAAAAA)\n".encode("utf-8"),
+            "FIXME_SHOULD_FAIL\n".encode("utf-8"),
         )
         await asyncio.sleep(0.1)
         await write_all(
             runtime,
             StdHandles.stdout,
-            "(BBBBBBBBBBBBB)\n".encode("utf-8"),
+            "just some text to see writing to a broken pipe\n".encode("utf-8"),
         )
-        await asyncio.sleep(0.1)
-        await write_all(
-            runtime,
-            StdHandles.stdout,
-            "(CCCCCCCCCCCCC)\n".encode("utf-8"),
-        )
-        raise RuntimeError("FIXME to see error handling in action")
 
     await write_all(
         runtime,
         StdHandles.stdout,
-        json.dumps(list(messages)).encode("utf-8"),
+        json.dumps(messages).encode("utf-8"),
     )
-
-    # FIXME
-    if "FIXME" in json.dumps(list(messages)):
-        raise RuntimeError("FIXME to see error handling in action")

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 from typing import Any, Dict
 from ailets.cons.atyping import INodeRuntime, StdHandles
@@ -23,26 +22,6 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
             keys,
         )
     )
-    # FIXME
-    if "FIXME" in json.dumps(list(messages)):
-        for i in range(3):
-            await write_all(
-                runtime,
-                StdHandles.stdout,
-                json.dumps(messages).encode("utf-8"),
-            )
-            await asyncio.sleep(0.1)
-        await write_all(
-            runtime,
-            StdHandles.stdout,
-            "FIXME_SHOULD_FAIL\n".encode("utf-8"),
-        )
-        await asyncio.sleep(0.1)
-        await write_all(
-            runtime,
-            StdHandles.stdout,
-            "just some text to see writing to a broken pipe\n".encode("utf-8"),
-        )
 
     await write_all(
         runtime,


### PR DESCRIPTION
- Catch an exception from an actor
- Create error codes, errno, get_errno, set_errno.
- Store-load "errno" of the environment, node runtime and pipes
- Print error in the dependency tree
- Start seqno from 10, to avoid collision with std handles
- Log fsops and process_progress handles
- Don't start new actors in case of error
- On error, promote the error to the previous and next actors
- Propagate an error into MemPipe
- Set cmdline exit code to the error code

close #133 