### PR TITLE
A103 cross boundary error code

### DIFF
--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -15,6 +15,7 @@ name = "actor_runtime"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "scan_json",
  "serde_json",
 ]
 
@@ -77,6 +78,7 @@ version = "0.1.0"
 dependencies = [
  "actor_io",
  "actor_runtime",
+ "getrandom",
 ]
 
 [[package]]

--- a/ailets-rs/actor_runtime/Cargo.toml
+++ b/ailets-rs/actor_runtime/Cargo.toml
@@ -14,4 +14,5 @@ dagops = []
 
 [dependencies]
 base64 = "0.22.1"
+scan_json = "1.0.1"
 serde_json = "1.0.140"

--- a/ailets-rs/actor_runtime/src/actor_runtime.rs
+++ b/ailets-rs/actor_runtime/src/actor_runtime.rs
@@ -2,6 +2,8 @@ use std::os::raw::{c_char, c_int, c_uint};
 
 #[link(wasm_import_module = "")]
 extern "C" {
+    pub fn get_errno() -> c_int;
+
     pub fn open_read(name_ptr: *const c_char) -> c_int;
     pub fn open_write(name_ptr: *const c_char) -> c_int;
     pub fn aread(fd: c_int, buffer_ptr: *mut u8, count: c_uint) -> c_int;

--- a/ailets-rs/actor_runtime/src/lib.rs
+++ b/ailets-rs/actor_runtime/src/lib.rs
@@ -34,3 +34,20 @@ pub fn err_to_heap_c_string(code: i32, message: &str) -> *const c_char {
     let err = Box::leak(Box::new(std::ffi::CString::new(error_str).unwrap()));
     err.as_ptr()
 }
+
+/// Look deep into an error and return the errno.
+#[must_use]
+#[allow(clippy::borrowed_box)]
+pub fn extract_errno(e: &Box<dyn std::error::Error>) -> i32 {
+    if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+        if let Some(code) = io_err.raw_os_error() {
+            return code;
+        }
+    }
+    if let Some(scan_json::Error::RJiterError(rj_err)) = e.downcast_ref::<scan_json::Error>() {
+        if let scan_json::rjiter::error::ErrorType::IoError(ref io_err) = rj_err.error_type {
+            return io_err.raw_os_error().unwrap_or(-1);
+        }
+    }
+    -1
+}

--- a/ailets-rs/actor_runtime/src/lib.rs
+++ b/ailets-rs/actor_runtime/src/lib.rs
@@ -4,7 +4,7 @@ mod actor_runtime;
 #[cfg(feature = "dagops")]
 mod dagops;
 
-pub use actor_runtime::{aclose, aread, awrite, open_read, open_write};
+pub use actor_runtime::{aclose, aread, awrite, get_errno, open_read, open_write};
 #[cfg(feature = "dagops")]
 pub use dagops::{DagOps, DagOpsTrait};
 

--- a/ailets-rs/actor_runtime/src/lib.rs
+++ b/ailets-rs/actor_runtime/src/lib.rs
@@ -24,8 +24,13 @@ pub enum StdHandle {
 /// This function is useful for returning errors to the host runtime.
 #[must_use]
 #[allow(clippy::missing_panics_doc)]
-pub fn err_to_heap_c_string(err: &str) -> *const c_char {
+pub fn err_to_heap_c_string(code: i32, message: &str) -> *const c_char {
+    let error_json = serde_json::json!({
+        "code": code,
+        "message": message
+    });
+    let error_str = error_json.to_string();
     #[allow(clippy::unwrap_used)]
-    let err = Box::leak(Box::new(std::ffi::CString::new(err).unwrap()));
+    let err = Box::leak(Box::new(std::ffi::CString::new(error_str).unwrap()));
     err.as_ptr()
 }

--- a/ailets-rs/cat/Cargo.toml
+++ b/ailets-rs/cat/Cargo.toml
@@ -9,3 +9,4 @@ crate-type = ["cdylib"]
 [dependencies] 
 actor_io = { version = "0.1.0", path = "../actor_io" }
 actor_runtime = { version = "0.1.0", path = "../actor_runtime" }
+getrandom = { version = "0.2", features = ["custom"] }

--- a/ailets-rs/cat/src/lib.rs
+++ b/ailets-rs/cat/src/lib.rs
@@ -9,14 +9,23 @@ pub extern "C" fn execute() -> *const c_char {
     let mut writer = AWriter::new_from_std(StdHandle::Stdout);
 
     if let Err(e) = io::copy(&mut reader, &mut writer) {
-        return err_to_heap_c_string(&format!("Failed to copy: {e}"));
+        return err_to_heap_c_string(
+            e.raw_os_error().unwrap_or(-1),
+            &format!("Failed to copy: {e}"),
+        );
     }
 
     if let Err(e) = writer.close() {
-        return err_to_heap_c_string(&format!("Failed to close writer: {e}"));
+        return err_to_heap_c_string(
+            e.raw_os_error().unwrap_or(-1),
+            &format!("Failed to close writer: {e}"),
+        );
     }
     if let Err(e) = reader.close() {
-        return err_to_heap_c_string(&format!("Failed to close reader: {e}"));
+        return err_to_heap_c_string(
+            e.raw_os_error().unwrap_or(-1),
+            &format!("Failed to close reader: {e}"),
+        );
     }
 
     std::ptr::null()

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -185,7 +185,12 @@ pub extern "C" fn process_gpt() -> *const c_char {
 
     let mut dagops = InjectDagOps::new(DagOps {});
     if let Err(e) = _process_gpt(reader, writer, &mut dagops) {
-        return err_to_heap_c_string(&format!("Failed to process GPT: {e}"));
+        let errno = if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+            io_err.raw_os_error().unwrap_or(-1)
+        } else {
+            -1
+        };
+        return err_to_heap_c_string(errno, &format!("Failed to process GPT: {e}"));
     }
     std::ptr::null()
 }

--- a/ailets-rs/messages_to_markdown/src/lib.rs
+++ b/ailets-rs/messages_to_markdown/src/lib.rs
@@ -85,7 +85,15 @@ pub extern "C" fn messages_to_markdown() -> *const c_char {
     let writer = AWriter::new_from_std(StdHandle::Stdout);
 
     if let Err(e) = _messages_to_markdown(reader, writer) {
-        return err_to_heap_c_string(&format!("Failed to process messages to markdown: {e}"));
+        let errno = if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+            io_err.raw_os_error().unwrap_or(-1)
+        } else {
+            -1
+        };
+        return err_to_heap_c_string(
+            errno,
+            &format!("Failed to process messages to markdown: {e}"),
+        );
     }
     std::ptr::null()
 }

--- a/ailets-rs/messages_to_markdown/src/lib.rs
+++ b/ailets-rs/messages_to_markdown/src/lib.rs
@@ -1,7 +1,7 @@
 mod structure_builder;
 
 use actor_io::{AReader, AWriter};
-use actor_runtime::{err_to_heap_c_string, StdHandle};
+use actor_runtime::{err_to_heap_c_string, extract_errno, StdHandle};
 use scan_json::jiter::Peek;
 use scan_json::RJiter;
 use scan_json::{scan, BoxedAction, ParentParentAndName, StreamOp, Trigger};
@@ -85,13 +85,8 @@ pub extern "C" fn messages_to_markdown() -> *const c_char {
     let writer = AWriter::new_from_std(StdHandle::Stdout);
 
     if let Err(e) = _messages_to_markdown(reader, writer) {
-        let errno = if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
-            io_err.raw_os_error().unwrap_or(-1)
-        } else {
-            -1
-        };
         return err_to_heap_c_string(
-            errno,
+            extract_errno(&e),
             &format!("Failed to process messages to markdown: {e}"),
         );
     }

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -169,7 +169,12 @@ pub extern "C" fn process_query() -> *const c_char {
     let writer = AWriter::new_from_std(StdHandle::Stdout);
 
     if let Err(e) = _process_query(reader, writer) {
-        return err_to_heap_c_string(&format!("Failed to process query: {e}"));
+        let errno = if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+            io_err.raw_os_error().unwrap_or(-1)
+        } else {
+            -1
+        };
+        return err_to_heap_c_string(errno, &format!("Failed to process query: {e}"));
     }
     std::ptr::null()
 }

--- a/ailets-rs/run_actor.py
+++ b/ailets-rs/run_actor.py
@@ -231,6 +231,9 @@ def register_node_runtime(
     def aclose(fd: int) -> int:
         return nr.aclose(fd)
 
+    def get_errno() -> int:
+        return -1
+
     def dag_instantiate_with_deps(workflow: int, deps: int) -> int:
         return nr.dag_instantiate_with_deps(
             buf_to_str.get_string(workflow),
@@ -260,6 +263,7 @@ def register_node_runtime(
             "aread": wasmer.Function(store, aread),
             "awrite": wasmer.Function(store, awrite),
             "aclose": wasmer.Function(store, aclose),
+            "get_errno": wasmer.Function(store, get_errno),
             "dag_instantiate_with_deps": wasmer.Function(
                 store, dag_instantiate_with_deps
             ),

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -189,7 +189,7 @@ class INodeRuntime(Protocol):
     async def write(self, fd: int, buffer: bytes, count: int) -> int:
         raise NotImplementedError
 
-    async def close(self, fd: int) -> None:
+    async def close(self, fd: int) -> int:
         raise NotImplementedError
 
     def dagops(self) -> INodeDagops:

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -174,6 +174,9 @@ class INodeRuntime(Protocol):
     def get_name(self) -> str:
         raise NotImplementedError
 
+    def get_errno(self) -> int:
+        raise NotImplementedError
+
     async def open_read(self, slot_name: str) -> int:
         raise NotImplementedError
 

--- a/pylib-v1/ailets/cons/atyping.py
+++ b/pylib-v1/ailets/cons/atyping.py
@@ -177,6 +177,9 @@ class INodeRuntime(Protocol):
     def get_errno(self) -> int:
         raise NotImplementedError
 
+    def set_errno(self, errno: int) -> None:
+        raise NotImplementedError
+
     async def open_read(self, slot_name: str) -> int:
         raise NotImplementedError
 

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -66,10 +66,10 @@ class NodeRuntime(INodeRuntime):
             if self.errno != 0:
                 reader = self.open_fds[fd].reader
                 if reader is not None and not reader.closed:
-                    reader.set_error(self.errno)
+                    reader.set_error(errno.EPIPE)
                 writer = self.open_fds[fd].writer
                 if writer is not None and not writer.closed:
-                    writer.set_error(self.errno)
+                    writer.set_error(errno.EPIPE)
             await self.close(fd)
             del self.open_fds[fd]
 

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -198,14 +198,14 @@ class NodeRuntime(INodeRuntime):
             self.logger.debug(f"Error writing to {fd_obj.debug_hint}: {e}")
             return -1
 
-    async def close(self, fd: int) -> None:
+    async def close(self, fd: int) -> int:
         fd_obj = self.open_fds.get(fd, None)
         if fd in self.fd_openers:
-            return
+            return 0
         if fd_obj is None:
             self.set_errno(errno.EBADF)
             self.logger.debug(f"File descriptor {fd} is not open")
-            return
+            return -1
 
         if fd_obj.reader is not None:
             if not fd_obj.reader.closed:
@@ -213,6 +213,7 @@ class NodeRuntime(INodeRuntime):
         if fd_obj.writer is not None:
             if not fd_obj.writer.closed:
                 fd_obj.writer.close()
+        return 0
 
     def dagops(self) -> INodeDagops:
         if self.cached_dagops is None:

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -1,3 +1,5 @@
+import errno
+import logging
 from dataclasses import dataclass
 from enum import Enum
 import sys
@@ -56,6 +58,7 @@ class NodeRuntime(INodeRuntime):
             StdHandles.trace: Opener.print,
         }
         self.errno: int = 0
+        self.logger = logging.getLogger(f"ailets.actor.{node_name}")
 
     async def destroy(self) -> None:
         fds = list(self.open_fds.keys())
@@ -138,13 +141,24 @@ class NodeRuntime(INodeRuntime):
     async def read(self, fd: int, buffer: bytearray, count: int) -> int:
         if fd not in self.open_fds and fd in self.fd_openers:
             await self.auto_open(StdHandles(fd))
-        assert fd in self.open_fds, f"File descriptor {fd} is not open"
+        if fd not in self.open_fds:
+            self.set_errno(errno.EBADF)
+            self.logger.error(f"File descriptor {fd} is not open")
+            return -1
 
         fd_obj = self.open_fds[fd]
-        assert (
-            fd_obj.reader is not None
-        ), f"Slot {fd_obj.debug_hint} is not open for reading"
-        read_bytes = await fd_obj.reader.read(count)
+        if fd_obj.reader is None:
+            self.set_errno(errno.EBADF)
+            self.logger.error(f"Slot {fd_obj.debug_hint} is not open for reading")
+            return -1
+
+        try:
+            read_bytes = await fd_obj.reader.read(count)
+        except OSError as e:
+            self.set_errno(e.errno)
+            self.logger.error(f"Error reading from {fd_obj.debug_hint}: {e}")
+            return -1
+
         n_bytes = len(read_bytes)
         buffer[:n_bytes] = read_bytes
         return n_bytes
@@ -166,19 +180,33 @@ class NodeRuntime(INodeRuntime):
     async def write(self, fd: int, buffer: bytes, count: int) -> int:
         if fd not in self.open_fds and fd in self.fd_openers:
             await self.auto_open(StdHandles(fd))
-        assert fd in self.open_fds, f"File descriptor {fd} is not open"
+        if fd not in self.open_fds:
+            self.set_errno(errno.EBADF)
+            self.logger.error(f"File descriptor {fd} is not open")
+            return -1
 
         fd_obj = self.open_fds[fd]
-        assert (
-            fd_obj.writer is not None
-        ), f"Slot {fd_obj.debug_hint} is not open for writing"
-        return await fd_obj.writer.write(buffer)
+        if fd_obj.writer is None:
+            self.set_errno(errno.EBADF)
+            self.logger.error(f"Slot {fd_obj.debug_hint} is not open for writing")
+            return -1
+
+        try:
+            return await fd_obj.writer.write(buffer)
+        except OSError as e:
+            self.set_errno(e.errno)
+            self.logger.error(f"Error writing to {fd_obj.debug_hint}: {e}")
+            return -1
 
     async def close(self, fd: int) -> None:
         fd_obj = self.open_fds.get(fd, None)
         if fd in self.fd_openers:
             return
-        assert fd_obj is not None, f"File descriptor {fd} is not open"
+        if fd_obj is None:
+            self.set_errno(errno.EBADF)
+            self.logger.error(f"File descriptor {fd} is not open")
+            return
+
         if fd_obj.reader is not None:
             if not fd_obj.reader.closed:
                 fd_obj.reader.close()

--- a/pylib-v1/ailets/cons/node_runtime.py
+++ b/pylib-v1/ailets/cons/node_runtime.py
@@ -143,20 +143,20 @@ class NodeRuntime(INodeRuntime):
             await self.auto_open(StdHandles(fd))
         if fd not in self.open_fds:
             self.set_errno(errno.EBADF)
-            self.logger.error(f"File descriptor {fd} is not open")
+            self.logger.debug(f"File descriptor {fd} is not open")
             return -1
 
         fd_obj = self.open_fds[fd]
         if fd_obj.reader is None:
             self.set_errno(errno.EBADF)
-            self.logger.error(f"Slot {fd_obj.debug_hint} is not open for reading")
+            self.logger.debug(f"Slot {fd_obj.debug_hint} is not open for reading")
             return -1
 
         try:
             read_bytes = await fd_obj.reader.read(count)
         except OSError as e:
             self.set_errno(e.errno)
-            self.logger.error(f"Error reading from {fd_obj.debug_hint}: {e}")
+            self.logger.debug(f"Error reading from {fd_obj.debug_hint}: {e}")
             return -1
 
         n_bytes = len(read_bytes)
@@ -182,20 +182,20 @@ class NodeRuntime(INodeRuntime):
             await self.auto_open(StdHandles(fd))
         if fd not in self.open_fds:
             self.set_errno(errno.EBADF)
-            self.logger.error(f"File descriptor {fd} is not open")
+            self.logger.debug(f"File descriptor {fd} is not open")
             return -1
 
         fd_obj = self.open_fds[fd]
         if fd_obj.writer is None:
             self.set_errno(errno.EBADF)
-            self.logger.error(f"Slot {fd_obj.debug_hint} is not open for writing")
+            self.logger.debug(f"Slot {fd_obj.debug_hint} is not open for writing")
             return -1
 
         try:
             return await fd_obj.writer.write(buffer)
         except OSError as e:
             self.set_errno(e.errno)
-            self.logger.error(f"Error writing to {fd_obj.debug_hint}: {e}")
+            self.logger.debug(f"Error writing to {fd_obj.debug_hint}: {e}")
             return -1
 
     async def close(self, fd: int) -> None:
@@ -204,7 +204,7 @@ class NodeRuntime(INodeRuntime):
             return
         if fd_obj is None:
             self.set_errno(errno.EBADF)
-            self.logger.error(f"File descriptor {fd} is not open")
+            self.logger.debug(f"File descriptor {fd} is not open")
             return
 
         if fd_obj.reader is not None:

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -49,6 +49,8 @@ def fill_wasm_import_object(
     async def aread(fd: int, buffer_ptr: int, count: int) -> int:
         buffer = bytearray(count)
         bytes_read = await runtime.read(fd, buffer, count)
+        if bytes_read == -1:
+            return -1
         buf_view = buf_to_str.get_view()
         end = buffer_ptr + bytes_read
         buf_view[buffer_ptr:end] = buffer[:bytes_read]
@@ -61,8 +63,7 @@ def fill_wasm_import_object(
         return await runtime.write(fd, buffer, count)
 
     async def aclose(fd: int) -> int:
-        await runtime.close(fd)
-        return 0
+        return await runtime.close(fd)
 
     async def dag_instantiate_with_deps(workflow_ptr: int, deps_ptr: int) -> int:
         workflow = buf_to_str.get_string(workflow_ptr)

--- a/pylib-v1/ailets/cons/node_runtime_wasm.py
+++ b/pylib-v1/ailets/cons/node_runtime_wasm.py
@@ -164,6 +164,9 @@ def fill_wasm_import_object(
     def sync_aclose(fd: int) -> int:
         return asyncio.run(aclose(fd))
 
+    def sync_get_errno() -> int:
+        return runtime.get_errno()
+
     def sync_dag_instantiate_with_deps(workflow_ptr: int, deps_ptr: int) -> int:
         return asyncio.run(dag_instantiate_with_deps(workflow_ptr, deps_ptr))
 
@@ -185,6 +188,7 @@ def fill_wasm_import_object(
             "aread": wasmer.Function(store, sync_aread),
             "awrite": wasmer.Function(store, sync_awrite),
             "aclose": wasmer.Function(store, sync_aclose),
+            "get_errno": wasmer.Function(store, sync_get_errno),
             "dag_instantiate_with_deps": wasmer.Function(
                 store, sync_dag_instantiate_with_deps
             ),

--- a/pylib-v1/ailets/cons/piper.py
+++ b/pylib-v1/ailets/cons/piper.py
@@ -46,8 +46,8 @@ class PrintWrapper(IPipe):
             return self.output.tell()
 
         def close(self) -> None:
-            # Don't close the wrapped writer, it's likely an instrumentation
-            # stream for which the app has own ownership.
+            if self.writer is not None:
+                self.writer.close()
             self.closed = True
 
         def get_error(self) -> int:
@@ -79,6 +79,9 @@ class PrintWrapper(IPipe):
         if self.pipe is None:
             raise io.UnsupportedOperation("PrintWrapper is write-only")
         return self.pipe.get_reader(handle)
+
+    def __str__(self) -> str:
+        return f"PrintWrapper(pipe={self.pipe}, " f"writer={self.writer})"
 
 
 class StaticInput(IPipe):

--- a/pylib-v1/ailets/cons/processes.py
+++ b/pylib-v1/ailets/cons/processes.py
@@ -213,7 +213,8 @@ class Processes(IProcesses):
                     self.pool.remove(awaker_task)
                 awaker_task = None
             if len(self.pool) > 0:
-                awaker_task = asyncio.create_task(awaker(), name="process.awaker")
+                if awaker_task is None:
+                    awaker_task = asyncio.create_task(awaker(), name="process.awaker")
                 self.pool.add(awaker_task)
 
         extend_pool()

--- a/pylib-v1/ailets/models/dalle/messages_to_query.py
+++ b/pylib-v1/ailets/models/dalle/messages_to_query.py
@@ -13,10 +13,9 @@ from ailets.cons.atyping import (
 )
 from ailets.cons.util import (
     log,
-    read_env_pipe,
     write_all,
 )
-from ailets.cons.input_reader import read_all
+from ailets.cons.input_reader import read_all, read_env_pipe
 
 
 # https://platform.openai.com/docs/api-reference/images/create

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 from typing import Any, Dict
 from ailets.cons.atyping import INodeRuntime, StdHandles
@@ -23,16 +22,6 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
             keys,
         )
     )
-    # FIXME
-    if "FIXME" in json.dumps(list(messages)):
-        for i in range(3):
-            await write_all(
-                runtime,
-                StdHandles.stdout,
-                json.dumps(messages).encode("utf-8"),
-            )
-            await asyncio.sleep(0.1)
-        raise Exception("FIXME testing: should break pipe")
 
     await write_all(
         runtime,

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import Any, Dict
 from ailets.cons.atyping import INodeRuntime, StdHandles
@@ -22,6 +23,27 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
             keys,
         )
     )
+    # FIXME
+    if "FIXME" in json.dumps(list(messages)):
+        for i in range(3):
+            await write_all(
+                runtime,
+                StdHandles.stdout,
+                json.dumps(messages).encode("utf-8"),
+            )
+            await asyncio.sleep(0.1)
+        for i in range(3):
+            await write_all(
+                runtime,
+                StdHandles.stdout,
+                "FIXME_SHOULD_FAIL\n".encode("utf-8"),
+            )
+            await asyncio.sleep(0.1)
+        await write_all(
+            runtime,
+            StdHandles.stdout,
+            "just some text to see writing to a broken pipe\n".encode("utf-8"),
+        )
 
     await write_all(
         runtime,

--- a/pylib-v1/ailets/stdlib/prompt_to_messages.py
+++ b/pylib-v1/ailets/stdlib/prompt_to_messages.py
@@ -32,18 +32,7 @@ async def prompt_to_messages(runtime: INodeRuntime) -> None:
                 json.dumps(messages).encode("utf-8"),
             )
             await asyncio.sleep(0.1)
-        for i in range(3):
-            await write_all(
-                runtime,
-                StdHandles.stdout,
-                "FIXME_SHOULD_FAIL\n".encode("utf-8"),
-            )
-            await asyncio.sleep(0.1)
-        await write_all(
-            runtime,
-            StdHandles.stdout,
-            "just some text to see writing to a broken pipe\n".encode("utf-8"),
-        )
+        raise Exception("FIXME testing: should break pipe")
 
     await write_all(
         runtime,


### PR DESCRIPTION
- In node runtime io, set "errno" and return -1
- Correct read/write/close implementation in wasm glue
- Py actors io react to io errors
- Add "get_errno" to rust, pass from Python
- In Rust, create os io errors from errno, extract on the top level
- Pass errno from Rust to py runtime
- Set EPIPE when promoting an error to pipes
- async fix: In Print-wrapper: close wrapped stream
- async fix: Don't create a new awaker if an old is useful

close #103 
