### PR TITLE
A167 refactor msg2query towards generalization

### DIFF
--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +250,7 @@ dependencies = [
  "base64",
  "getrandom",
  "hamcrest",
+ "linked-hash-map",
  "scan_json 1.0.3",
  "serde",
  "serde_json",

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -19,6 +19,7 @@ getrandom = { version = "0.2", features = ["custom"] }
 scan_json = { version = "1.0.3", path = "../../../streaming_json/scan_json" }
 serde = { version = "1.0.219", features = ["derive"] }
 base64 = "0.22.1"
+linked-hash-map = "0.5.6"
 
 [dev-dependencies]
 hamcrest = "0.1.5"

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -171,7 +171,7 @@ pub fn on_item_attribute_content_type<W: Write>(
         }
     };
     let mut builder = builder_cell.borrow_mut();
-    if let Err(e) = builder.set_item_attribute(String::from("content_type"), String::from(value)) {
+    if let Err(e) = builder.add_item_attribute(String::from("content_type"), String::from(value)) {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed
@@ -191,7 +191,7 @@ pub fn on_item_attribute_detail<W: Write>(
         }
     };
     let mut builder = builder_cell.borrow_mut();
-    if let Err(e) = builder.set_item_attribute(String::from("detail"), String::from(value)) {
+    if let Err(e) = builder.add_item_attribute(String::from("detail"), String::from(value)) {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -58,7 +58,7 @@ pub fn on_content_item_type<W: Write>(
     };
     if let Err(e) = builder_cell
         .borrow_mut()
-        .add_item_type(item_type.to_string())
+        .add_item_attribute(String::from("type"), item_type.to_string())
     {
         return StreamOp::Error(e.into());
     }

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -18,7 +18,7 @@ pub fn on_role<W: Write>(
             );
         }
     };
-    if let Err(e) = builder_cell.borrow_mut().add_role(role) {
+    if let Err(e) = builder_cell.borrow_mut().handle_role(role) {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -24,26 +24,26 @@ pub fn on_role<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_content_item_begin<W: Write>(
+pub fn on_item_begin<W: Write>(
     _rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
     let mut builder = builder_cell.borrow_mut();
-    if let Err(e) = builder.begin_content_item() {
+    if let Err(e) = builder.begin_item() {
         return StreamOp::Error(e.into());
     }
     StreamOp::None
 }
 
-pub fn on_content_item_end<W: Write>(
+pub fn on_item_end<W: Write>(
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut builder = builder_cell.borrow_mut();
-    builder.end_content_item()?;
+    builder.end_item()?;
     Ok(())
 }
 
-pub fn on_content_item_type<W: Write>(
+pub fn on_item_type<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -65,7 +65,7 @@ pub fn on_content_item_type<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_content_text<W: Write>(
+pub fn on_item_text<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -101,7 +101,7 @@ pub fn on_content_text<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_content_image_url<W: Write>(
+pub fn on_item_image_url<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -137,7 +137,7 @@ pub fn on_content_image_url<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_content_image_key<W: Write>(
+pub fn on_item_image_key<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -156,7 +156,7 @@ pub fn on_content_image_key<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_content_item_attribute_content_type<W: Write>(
+pub fn on_item_attribute_content_type<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -171,15 +171,13 @@ pub fn on_content_item_attribute_content_type<W: Write>(
         }
     };
     let mut builder = builder_cell.borrow_mut();
-    if let Err(e) =
-        builder.set_content_item_attribute(String::from("content_type"), String::from(value))
-    {
+    if let Err(e) = builder.set_item_attribute(String::from("content_type"), String::from(value)) {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_content_item_attribute_detail<W: Write>(
+pub fn on_item_attribute_detail<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -193,8 +191,7 @@ pub fn on_content_item_attribute_detail<W: Write>(
         }
     };
     let mut builder = builder_cell.borrow_mut();
-    if let Err(e) = builder.set_content_item_attribute(String::from("detail"), String::from(value))
-    {
+    if let Err(e) = builder.set_item_attribute(String::from("detail"), String::from(value)) {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -22,73 +22,71 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         Box::new(ParentAndName::new("#array".to_string(), "role".to_string())),
         Box::new(handlers::on_role) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_item = Trigger::new(
+    let item = Trigger::new(
         Box::new(ParentAndName::new("#top".to_string(), "#array".to_string())),
-        Box::new(handlers::on_content_item_begin) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_begin) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_item_type = Trigger::new(
+    let item_type = Trigger::new(
         Box::new(ParentAndName::new("#array".to_string(), "type".to_string())),
-        Box::new(handlers::on_content_item_type) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_type) as BoxedAction<'_, StructureBuilder<W>>,
     );
 
     //
     // Content items
     //
-    let content_text = Trigger::new(
+    let text = Trigger::new(
         Box::new(ParentAndName::new("#array".to_string(), "text".to_string())),
-        Box::new(handlers::on_content_text) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_text) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_image_url = Trigger::new(
+    let image_url = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "image_url".to_string(),
         )),
-        Box::new(handlers::on_content_image_url) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_image_url) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_image_key = Trigger::new(
+    let image_key = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "image_key".to_string(),
         )),
-        Box::new(handlers::on_content_image_key) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_image_key) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_item_attribute_content_type = Trigger::new(
+    let attr_content_type = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "content_type".to_string(),
         )),
-        Box::new(handlers::on_content_item_attribute_content_type)
-            as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_attribute_content_type) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let content_item_attribute_detail = Trigger::new(
+    let attr_detail = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "detail".to_string(),
         )),
-        Box::new(handlers::on_content_item_attribute_detail)
-            as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_attribute_detail) as BoxedAction<'_, StructureBuilder<W>>,
     );
 
     vec![
-        content_item_type,
-        content_text,
-        content_image_url,
-        content_image_key,
-        content_item,
-        content_item_attribute_content_type,
-        content_item_attribute_detail,
+        item_type,
+        text,
+        image_url,
+        image_key,
+        item,
+        attr_content_type,
+        attr_detail,
         role,
     ]
 }
 
 fn create_end_triggers<'a, W: Write + 'a>(
 ) -> Vec<Trigger<'a, BoxedEndAction<'a, StructureBuilder<W>>>> {
-    let content_item = Trigger::new(
+    let item = Trigger::new(
         Box::new(ParentAndName::new("#top".to_string(), "#array".to_string())),
-        Box::new(handlers::on_content_item_end) as BoxedEndAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_item_end) as BoxedEndAction<'_, StructureBuilder<W>>,
     );
 
-    vec![content_item]
+    vec![item]
 }
 
 /// # Errors

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -3,8 +3,8 @@ use actor_io::AReader;
 use actor_runtime::annotate_error;
 use base64::engine::general_purpose::STANDARD;
 use base64::write::EncoderWriter as Base64Encoder;
+use linked_hash_map::LinkedHashMap;
 use serde::Serialize;
-use std::collections::HashMap;
 use std::io;
 use std::io::Write;
 
@@ -51,7 +51,7 @@ pub struct StructureBuilder<W: Write> {
     message: Progress,
     message_content: Progress,
     content_item: Progress,
-    content_item_attr: Option<HashMap<String, String>>,
+    content_item_attr: Option<LinkedHashMap<String, String>>,
     env_opts: EnvOpts,
 }
 
@@ -242,7 +242,7 @@ impl<W: Write> StructureBuilder<W> {
         self.content_item = Progress::ChildrenAreUnexpected;
         if self.content_item_attr.is_none() {
             // Signal that "content" key is present
-            self.content_item_attr = Some(HashMap::new());
+            self.content_item_attr = Some(LinkedHashMap::new());
         }
         Ok(())
     }
@@ -339,7 +339,7 @@ impl<W: Write> StructureBuilder<W> {
             return Err("Content item is not started".to_string());
         }
         if self.content_item_attr.is_none() {
-            self.content_item_attr = Some(HashMap::new());
+            self.content_item_attr = Some(LinkedHashMap::new());
         }
         if let Some(ref mut attrs) = self.content_item_attr {
             if key == "type" {
@@ -458,7 +458,7 @@ impl<W: Write> StructureBuilder<W> {
             return Err("Content item is not started".to_string());
         }
         if self.content_item_attr.is_none() {
-            self.content_item_attr = Some(HashMap::new());
+            self.content_item_attr = Some(LinkedHashMap::new());
         }
         if let Some(ref mut attrs) = self.content_item_attr {
             attrs.insert(key, value);

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -349,6 +349,7 @@ impl<W: Write> StructureBuilder<W> {
 
     /// # Errors
     /// - content item is not started
+    /// - for "type" attribute, the value is unknown or conflicting with the already typed item
     /// - I/O
     pub fn add_item_attribute(&mut self, key: String, value: String) -> Result<(), String> {
         if let ItemAttrMode::RaiseError = self.item_attr_mode {
@@ -457,21 +458,5 @@ impl<W: Write> StructureBuilder<W> {
         drop(encoder);
 
         self.end_image_url()
-    }
-
-    /// # Errors
-    /// - content item is not started
-    /// - I/O
-    pub fn set_item_attribute(&mut self, key: String, value: String) -> Result<(), String> {
-        if let ItemAttrMode::RaiseError = self.item_attr_mode {
-            return Err("Content item is not started".to_string());
-        }
-        if self.item_attr.is_none() {
-            self.item_attr = Some(LinkedHashMap::new());
-        }
-        if let Some(ref mut attrs) = self.item_attr {
-            attrs.insert(key, value);
-        }
-        Ok(())
     }
 }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -409,4 +409,20 @@ impl<W: Write> StructureBuilder<W> {
         }
         Ok(())
     }
+
+    /// # Errors
+    /// - content item is not started
+    /// - I/O
+    pub fn add_item_attribute(&mut self, key: String, value: String) -> Result<(), String> {
+        if let Progress::ChildrenAreUnexpected = self.content_item {
+            return Err("Content item is not started".to_string());
+        }
+        if self.content_item_attr.is_none() {
+            self.content_item_attr = Some(HashMap::new());
+        }
+        if let Some(ref mut attrs) = self.content_item_attr {
+            attrs.insert(key, value);
+        }
+        Ok(())
+    }
 }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -309,7 +309,9 @@ impl<W: Write> StructureBuilder<W> {
             .ok_or_else(|| "Content item type is not set".to_string())?;
 
         if item_type != "ctl" {
-            return Err(format!("Expected type 'ctl', got '{item_type}'"));
+            return Err(format!(
+                "For 'role' attribute, expected item type 'ctl', got '{item_type}'"
+            ));
         }
 
         self.begin_message(role)

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -369,7 +369,16 @@ impl<W: Write> StructureBuilder<W> {
         }
         self.add_item_attribute(String::from("type"), String::from("text"))?;
         self.really_begin_content_item()?;
-        write!(self.writer, r#""type":"text","text":""#).map_err(|e| e.to_string())?;
+
+        if let Some(ref attrs) = self.content_item_attr {
+            for (key, value) in attrs {
+                write!(self.writer, r#""{key}":"#).map_err(|e| e.to_string())?;
+                serde_json::to_writer(&mut self.writer, value).map_err(|e| e.to_string())?;
+                write!(self.writer, r#","#).map_err(|e| e.to_string())?;
+            }
+        }
+
+        write!(self.writer, r#""text":""#).map_err(|e| e.to_string())?;
         Ok(())
     }
 

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -282,7 +282,9 @@ impl<W: Write> StructureBuilder<W> {
         if let Progress::ChildrenAreUnexpected = self.content_item {
             return Err("Content item is not started".to_string());
         }
-        let item_type = self.content_item_attr.as_ref()
+        let item_type = self
+            .content_item_attr
+            .as_ref()
             .ok_or_else(|| "Content item attributes are not set".to_string())?
             .get("type")
             .ok_or_else(|| "Content item type is not set".to_string())?;
@@ -296,7 +298,9 @@ impl<W: Write> StructureBuilder<W> {
             self.writer.write_all(b",").map_err(|e| e.to_string())?;
         }
 
-        let role = self.content_item_attr.as_ref()
+        let role = self
+            .content_item_attr
+            .as_ref()
             .ok_or_else(|| "Content item attributes are not set".to_string())?
             .get("role")
             .ok_or_else(|| "Role attribute is not set".to_string())?;
@@ -328,7 +332,7 @@ impl<W: Write> StructureBuilder<W> {
     /// # Errors
     /// - content item is not started
     /// - I/O
-    pub fn add_item_type(&mut self, item_type: String) -> Result<(), String> {
+    pub fn add_item_attribute(&mut self, key: String, value: String) -> Result<(), String> {
         if let Progress::ChildrenAreUnexpected = self.content_item {
             return Err("Content item is not started".to_string());
         }
@@ -336,15 +340,7 @@ impl<W: Write> StructureBuilder<W> {
             self.content_item_attr = Some(HashMap::new());
         }
         if let Some(ref mut attrs) = self.content_item_attr {
-            if let Some(existing_type) = attrs.get("type") {
-                if existing_type != &item_type {
-                    return Err(format!(
-                        "Wrong content item type: already typed as \"{existing_type}\", new type is \"{item_type}\""
-                    ));
-                }
-            } else {
-                attrs.insert(String::from("type"), item_type);
-            }
+            attrs.insert(key, value);
         }
         Ok(())
     }
@@ -356,7 +352,7 @@ impl<W: Write> StructureBuilder<W> {
         if let Progress::ChildrenAreUnexpected = self.content_item {
             return Err("Content item is not started".to_string());
         }
-        self.add_item_type(String::from("text"))?;
+        self.add_item_attribute(String::from("type"), String::from("text"))?;
         self.really_begin_content_item()?;
         write!(self.writer, r#""type":"text","text":""#).map_err(|e| e.to_string())?;
         Ok(())
@@ -376,7 +372,7 @@ impl<W: Write> StructureBuilder<W> {
         if let Progress::ChildrenAreUnexpected = self.content_item {
             return Err("Content item is not started".to_string());
         }
-        self.add_item_type(String::from("image"))?;
+        self.add_item_attribute(String::from("type"), String::from("image"))?;
         self.really_begin_content_item()?;
         write!(self.writer, r#""type":"image_url","image_url":{{"#).map_err(|e| e.to_string())?;
         if let Some(ref attrs) = self.content_item_attr {
@@ -434,22 +430,6 @@ impl<W: Write> StructureBuilder<W> {
     /// - content item is not started
     /// - I/O
     pub fn set_content_item_attribute(&mut self, key: String, value: String) -> Result<(), String> {
-        if let Progress::ChildrenAreUnexpected = self.content_item {
-            return Err("Content item is not started".to_string());
-        }
-        if self.content_item_attr.is_none() {
-            self.content_item_attr = Some(HashMap::new());
-        }
-        if let Some(ref mut attrs) = self.content_item_attr {
-            attrs.insert(key, value);
-        }
-        Ok(())
-    }
-
-    /// # Errors
-    /// - content item is not started
-    /// - I/O
-    pub fn add_item_attribute(&mut self, key: String, value: String) -> Result<(), String> {
         if let Progress::ChildrenAreUnexpected = self.content_item {
             return Err("Content item is not started".to_string());
         }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -275,13 +275,15 @@ impl<W: Write> StructureBuilder<W> {
                     }
                     Some(item_type) => {
                         write!(self.writer, r#"{{"type":"#).map_err(|e| e.to_string())?;
-                        serde_json::to_writer(&mut self.writer, item_type).map_err(|e| e.to_string())?;
+                        serde_json::to_writer(&mut self.writer, item_type)
+                            .map_err(|e| e.to_string())?;
                     }
                 }
-                for (key, value) in attrs.iter() {
+                for (key, value) in attrs {
                     if key != "type" {
                         write!(self.writer, r#",""{key}":"#).map_err(|e| e.to_string())?;
-                        serde_json::to_writer(&mut self.writer, value).map_err(|e| e.to_string())?;
+                        serde_json::to_writer(&mut self.writer, value)
+                            .map_err(|e| e.to_string())?;
                     }
                 }
             }
@@ -337,8 +339,8 @@ impl<W: Write> StructureBuilder<W> {
             .get("role")
             .ok_or_else(|| "Role attribute is not set".to_string())?;
 
-        write!(self.writer, r#""role":"{role}","content":[
-"#).map_err(|e| e.to_string())?;
+        write!(self.writer, r#""role":"{role}","content":["#).map_err(|e| e.to_string())?;
+        self.writer.write_all(b"\n").map_err(|e| e.to_string())?;
         self.message = Progress::ChildIsWritten;
         self.message_content = Progress::WaitingForFirstChild;
         self.item_attr_mode = ItemAttrMode::Drop;

--- a/ailets-rs/messages_to_query/tests/env_opts_test.rs
+++ b/ailets-rs/messages_to_query/tests/env_opts_test.rs
@@ -40,14 +40,17 @@ fn test_env_opts_invalid_json() {
 fn _build_with_env_opts(env_opts: EnvOpts) -> String {
     let writer = RcWriter::new();
     let mut builder = StructureBuilder::new(writer.clone(), env_opts);
-    builder.begin_content_item().unwrap();
-    builder.add_role("user").unwrap();
-    builder.end_content_item().unwrap();
-    builder.begin_content_item().unwrap();
+    builder.begin_item().unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("ctl"))
+        .unwrap();
+    builder.handle_role("user").unwrap();
+    builder.end_item().unwrap();
+    builder.begin_item().unwrap();
     builder.begin_text().unwrap();
     write!(builder.get_writer(), "Hello!").unwrap();
     builder.end_text().unwrap();
-    builder.end_content_item().unwrap();
+    builder.end_item().unwrap();
     builder.end().unwrap();
     writer.get_output()
 }

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -252,7 +252,7 @@ fn pass_preceding_attributes_to_text_output() {
         .add_item_attribute(String::from("type"), String::from("text"))
         .unwrap();
     builder
-        .add_item_attribute(String::from("custom_attr_3"), String::from("value_3"))
+        .add_item_attribute(String::from("custom_attr_2"), String::from("value_2"))
         .unwrap();
 
     builder.begin_text().unwrap();
@@ -261,7 +261,7 @@ fn pass_preceding_attributes_to_text_output() {
     builder.end_content_item().unwrap();
     builder.end().unwrap();
 
-    let expected_text_item = r#"{"type":"text","custom_attr_1":"value_1","custom_attr_3":"value_3","text":"Hello world"}"#;
+    let expected_text_item = r#"{"type":"text","custom_attr_1":"value_1","custom_attr_2":"value_2","text":"Hello world"}"#;
     assert_that!(
         writer.get_output(),
         equal_to(wrap_boilerplate(&format!(

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -351,7 +351,7 @@ fn add_image_by_key() {
         .add_item_attribute(String::from("type"), String::from("image"))
         .unwrap();
     builder
-        .set_item_attribute(String::from("content_type"), String::from("image/png"))
+        .add_item_attribute(String::from("content_type"), String::from("image/png"))
         .unwrap();
     builder.image_key("media/image-as-key-1.png").unwrap();
 
@@ -382,7 +382,7 @@ fn image_as_key_file_not_found() {
         .add_item_attribute(String::from("type"), String::from("image"))
         .unwrap();
     builder
-        .set_item_attribute(String::from("content_type"), String::from("image/png"))
+        .add_item_attribute(String::from("content_type"), String::from("image/png"))
         .unwrap();
 
     let result = builder.image_key("media/nonexistent.png");
@@ -408,7 +408,7 @@ fn add_image_with_detail() {
         .add_item_attribute(String::from("type"), String::from("image"))
         .unwrap();
     builder
-        .set_item_attribute(String::from("detail"), String::from("high"))
+        .add_item_attribute(String::from("detail"), String::from("high"))
         .unwrap();
     builder.begin_image_url().unwrap();
     builder
@@ -445,7 +445,7 @@ fn image_key_with_adversarial_content_type() {
         .add_item_attribute(String::from("type"), String::from("image"))
         .unwrap();
     builder
-        .set_item_attribute(
+        .add_item_attribute(
             String::from("content_type"),
             String::from("\"\"image/png\0\\/\"';\u{202E}\u{2028}"),
         )
@@ -483,10 +483,10 @@ fn image_settings_dont_transfer() {
         .add_item_attribute(String::from("type"), String::from("image"))
         .unwrap();
     builder
-        .set_item_attribute(String::from("content_type"), String::from("image/png"))
+        .add_item_attribute(String::from("content_type"), String::from("image/png"))
         .unwrap();
     builder
-        .set_item_attribute(String::from("detail"), String::from("high"))
+        .add_item_attribute(String::from("detail"), String::from("high"))
         .unwrap();
     builder.begin_image_url().unwrap();
     builder

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -24,8 +24,9 @@ fn create_empty_env_opts() -> EnvOpts {
 
 fn begin_message(builder: &mut StructureBuilder<RcWriter>, role: &str) {
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("ctl")).unwrap();
-    builder.add_role(role).unwrap();
+    builder.add_item_attribute(String::from("type"), String::from("ctl")).unwrap();
+    builder.add_item_attribute(String::from("role"), String::from(role)).unwrap();
+    builder.handle_role().unwrap();
     builder.end_content_item().unwrap();
 }
 
@@ -37,6 +38,7 @@ fn happy_path_for_text() {
 
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
+    builder.add_item_attribute(String::from("type"), String::from("text")).unwrap();
     builder.begin_text().unwrap();
     write!(builder.get_writer(), "Hello!").unwrap();
     builder.end_text().unwrap();

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -24,8 +24,12 @@ fn create_empty_env_opts() -> EnvOpts {
 
 fn begin_message(builder: &mut StructureBuilder<RcWriter>, role: &str) {
     builder.begin_content_item().unwrap();
-    builder.add_item_attribute(String::from("type"), String::from("ctl")).unwrap();
-    builder.add_item_attribute(String::from("role"), String::from(role)).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("ctl"))
+        .unwrap();
+    builder
+        .add_item_attribute(String::from("role"), String::from(role))
+        .unwrap();
     builder.handle_role().unwrap();
     builder.end_content_item().unwrap();
 }
@@ -38,7 +42,9 @@ fn happy_path_for_text() {
 
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
-    builder.add_item_attribute(String::from("type"), String::from("text")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
     builder.begin_text().unwrap();
     write!(builder.get_writer(), "Hello!").unwrap();
     builder.end_text().unwrap();

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -27,10 +27,7 @@ fn begin_message(builder: &mut StructureBuilder<RcWriter>, role: &str) {
     builder
         .add_item_attribute(String::from("type"), String::from("ctl"))
         .unwrap();
-    builder
-        .add_item_attribute(String::from("role"), String::from(role))
-        .unwrap();
-    builder.handle_role().unwrap();
+    builder.handle_role(role).unwrap();
     builder.end_item().unwrap();
 }
 

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -138,6 +138,24 @@ fn several_contentless_roles_create_several_messages_anyway() {
 }
 
 #[test]
+fn reject_role_for_non_ctl_type() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());
+    let mut builder = builder;
+
+    builder.begin_item().unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
+
+    let err = builder.handle_role("user").unwrap_err();
+    assert_that!(
+        err,
+        equal_to("For 'role' attribute, expected item type 'ctl', got 'text'".to_string())
+    );
+}
+
+#[test]
 fn auto_generate_type_text() {
     let writer = RcWriter::new();
     let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -160,6 +160,23 @@ fn auto_generate_type_text() {
 }
 
 #[test]
+fn reject_unknown_type() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());
+    let mut builder = builder;
+    begin_message(&mut builder, "user");
+
+    builder.begin_content_item().unwrap();
+    let err = builder
+        .add_item_attribute(String::from("type"), String::from("unknown"))
+        .unwrap_err();
+    assert_that!(
+        err,
+        equal_to("Invalid type value: 'unknown'. Allowed values are: text, image, ctl".to_string())
+    );
+}
+
+#[test]
 fn reject_conflicting_type() {
     let writer = RcWriter::new();
     let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -258,7 +258,7 @@ fn pass_preceding_attributes_to_text_output() {
     builder.end_item().unwrap();
     builder.end().unwrap();
 
-    let expected_text_item = r#"{"custom_attr_1":"value_1","type":"text","custom_attr_2":"value_2","text":"Hello world"}"#;
+    let expected_text_item = r#"{"type":"text","custom_attr_1":"value_1","custom_attr_2":"value_2","text":"Hello world"}"#;
     assert_that!(
         writer.get_output(),
         equal_to(wrap_boilerplate(&format!(

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -160,32 +160,6 @@ fn auto_generate_type_text() {
 }
 
 #[test]
-fn mix_type_text() {
-    let writer = RcWriter::new();
-    let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());
-    let mut builder = builder;
-    begin_message(&mut builder, "user");
-
-    builder.begin_content_item().unwrap();
-    builder.begin_content_item().unwrap();
-    builder
-        .add_item_attribute(String::from("type"), String::from("text"))
-        .unwrap();
-    builder.begin_text().unwrap();
-    write!(builder.get_writer(), "hello").unwrap();
-    builder.end_text().unwrap();
-    builder
-        .add_item_attribute(String::from("type"), String::from("text"))
-        .unwrap();
-    builder.end_content_item().unwrap();
-    builder.end().unwrap();
-
-    let expected =
-        wrap_boilerplate(r#"{"role":"user","content":[_NL_{"type":"text","text":"hello"}_NL_]}"#);
-    assert_that!(writer.get_output(), equal_to(expected));
-}
-
-#[test]
 fn reject_conflicting_type() {
     let writer = RcWriter::new();
     let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -168,11 +168,15 @@ fn mix_type_text() {
 
     builder.begin_content_item().unwrap();
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("text")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
     builder.begin_text().unwrap();
     write!(builder.get_writer(), "hello").unwrap();
     builder.end_text().unwrap();
-    builder.add_item_type(String::from("text")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
     builder.end_content_item().unwrap();
     builder.end().unwrap();
 
@@ -189,8 +193,12 @@ fn reject_conflicting_type() {
     begin_message(&mut builder, "user");
 
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("text")).unwrap();
-    let err = builder.add_item_type(String::from("image")).unwrap_err();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
+    let err = builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap_err();
     assert_that!(
         err,
         equal_to(
@@ -200,7 +208,9 @@ fn reject_conflicting_type() {
 
     // Different content items have different types
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
 }
 
 #[test]
@@ -213,7 +223,9 @@ fn support_special_chars_and_unicode() {
 
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("text")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
     builder.begin_text().unwrap();
     builder
         .get_writer()
@@ -242,7 +254,9 @@ fn add_image_by_url() {
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
 
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder.begin_image_url().unwrap();
     builder
         .get_writer()
@@ -275,7 +289,9 @@ fn add_image_by_key() {
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
 
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder
         .set_content_item_attribute(String::from("content_type"), String::from("image/png"))
         .unwrap();
@@ -304,7 +320,9 @@ fn image_as_key_file_not_found() {
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
 
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder
         .set_content_item_attribute(String::from("content_type"), String::from("image/png"))
         .unwrap();
@@ -328,7 +346,9 @@ fn add_image_with_detail() {
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
 
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder
         .set_content_item_attribute(String::from("detail"), String::from("high"))
         .unwrap();
@@ -363,7 +383,9 @@ fn image_key_with_adversarial_content_type() {
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
 
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder
         .set_content_item_attribute(
             String::from("content_type"),
@@ -399,7 +421,9 @@ fn image_settings_dont_transfer() {
 
     // First image with content_type and detail
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder
         .set_content_item_attribute(String::from("content_type"), String::from("image/png"))
         .unwrap();
@@ -416,7 +440,9 @@ fn image_settings_dont_transfer() {
 
     // Second image without content_type and detail
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder.begin_image_url().unwrap();
     builder
         .get_writer()
@@ -449,7 +475,9 @@ fn mix_text_and_image_content() {
 
     // Text item
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("text")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
     builder.begin_text().unwrap();
     write!(builder.get_writer(), "Hello world").unwrap();
     builder.end_text().unwrap();
@@ -457,7 +485,9 @@ fn mix_text_and_image_content() {
 
     // Image item
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("image")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("image"))
+        .unwrap();
     builder.begin_image_url().unwrap();
     builder
         .get_writer()
@@ -468,7 +498,9 @@ fn mix_text_and_image_content() {
 
     // Another text item
     builder.begin_content_item().unwrap();
-    builder.add_item_type(String::from("text")).unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("text"))
+        .unwrap();
     builder.begin_text().unwrap();
     write!(builder.get_writer(), "Another text").unwrap();
     builder.end_text().unwrap();

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -235,6 +235,7 @@ fn support_special_chars_and_unicode() {
     );
     assert_that!(writer.get_output(), equal_to(expected));
 }
+
 #[test]
 fn pass_preceding_attributes_to_text_output() {
     let writer = RcWriter::new();
@@ -261,6 +262,38 @@ fn pass_preceding_attributes_to_text_output() {
     builder.end().unwrap();
 
     let expected_text_item = r#"{"custom_attr_1":"value_1","type":"text","custom_attr_2":"value_2","text":"Hello world"}"#;
+    assert_that!(
+        writer.get_output(),
+        equal_to(wrap_boilerplate(&format!(
+            r#"{{"role":"user","content":[_NL_{}_NL_]}}"#,
+            expected_text_item
+        )))
+    );
+}
+
+#[test]
+fn pass_following_attributes_to_text_output() {
+    let writer = RcWriter::new();
+    let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());
+    let mut builder = builder;
+
+    begin_message(&mut builder, "user");
+    builder.begin_content_item().unwrap();
+    builder.begin_text().unwrap();
+    write!(builder.get_writer(), "Hello world").unwrap();
+    builder.end_text().unwrap();
+
+    builder
+        .add_item_attribute(String::from("custom_attr_3"), String::from("value_3"))
+        .unwrap();
+    builder
+        .add_item_attribute(String::from("custom_attr_4"), String::from("value_4"))
+        .unwrap();
+
+    builder.end_content_item().unwrap();
+    builder.end().unwrap();
+
+    let expected_text_item = r#"{"type":"text","text":"Hello world","custom_attr_3":"value_3","custom_attr_4":"value_4"}"#;
     assert_that!(
         writer.get_output(),
         equal_to(wrap_boilerplate(&format!(

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -244,7 +244,6 @@ fn pass_preceding_attributes_to_text_output() {
     begin_message(&mut builder, "user");
     builder.begin_content_item().unwrap();
 
-    // Set attributes before text handler
     builder
         .add_item_attribute(String::from("custom_attr_1"), String::from("value_1"))
         .unwrap();
@@ -261,7 +260,7 @@ fn pass_preceding_attributes_to_text_output() {
     builder.end_content_item().unwrap();
     builder.end().unwrap();
 
-    let expected_text_item = r#"{"type":"text","custom_attr_1":"value_1","custom_attr_2":"value_2","text":"Hello world"}"#;
+    let expected_text_item = r#"{"custom_attr_1":"value_1","type":"text","custom_attr_2":"value_2","text":"Hello world"}"#;
     assert_that!(
         writer.get_output(),
         equal_to(wrap_boilerplate(&format!(


### PR DESCRIPTION
- Collect attributes for use in a handler
- Pass-through attributes after a handler
- Reduce progress states to one `Divider`

Part of #167 