### PR TITLE
A174 repair tool specifications in messages-to-query

### DIFF
--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
  "getrandom",
  "hamcrest",
  "linked-hash-map",
- "scan_json 1.0.3",
+ "scan_json 1.1.0",
  "serde",
  "serde_json",
 ]
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "scan_json"
-version = "1.0.3"
+version = "1.1.0"
 dependencies = [
  "rjiter",
 ]

--- a/ailets-rs/Cargo.lock
+++ b/ailets-rs/Cargo.lock
@@ -15,7 +15,7 @@ name = "actor_runtime"
 version = "0.2.0"
 dependencies = [
  "base64",
- "scan_json 1.0.2",
+ "scan_json",
  "serde_json",
 ]
 
@@ -119,7 +119,7 @@ dependencies = [
  "actor_runtime_mocked",
  "getrandom",
  "hamcrest",
- "scan_json 1.0.2",
+ "scan_json",
  "serde_json",
 ]
 
@@ -237,7 +237,7 @@ dependencies = [
  "actor_runtime",
  "actor_runtime_mocked",
  "getrandom",
- "scan_json 1.0.2",
+ "scan_json",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ dependencies = [
  "getrandom",
  "hamcrest",
  "linked-hash-map",
- "scan_json 1.1.0",
+ "scan_json",
  "serde",
  "serde_json",
 ]
@@ -528,16 +528,9 @@ checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "scan_json"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d3cd27a3cb591249884932704555c5ba91092b61813b32fe7ec528026127ee1"
-dependencies = [
- "rjiter",
-]
-
-[[package]]
-name = "scan_json"
 version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b52ee5c681537b33669400939486b0b008406e06ff2b3e7cf9d8b6c974e0dd02"
 dependencies = [
  "rjiter",
 ]

--- a/ailets-rs/actor_runtime/Cargo.toml
+++ b/ailets-rs/actor_runtime/Cargo.toml
@@ -14,5 +14,5 @@ dagops = []
 
 [dependencies]
 base64 = "0.22.1"
-scan_json = "1.0.2"
+scan_json = "1.1.0"
 serde_json = "1.0.140"

--- a/ailets-rs/gpt/Cargo.toml
+++ b/ailets-rs/gpt/Cargo.toml
@@ -14,7 +14,7 @@ actor_runtime = { version = "0.2.0", path = "../actor_runtime", features = ["dag
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 actor_io = { version = "0.1.0", path = "../actor_io" }
 serde_json = "1.0.139"
-scan_json = "1.0.2"
+scan_json = "1.1.0"
 
 [dev-dependencies]
 hamcrest = "0.1.5"

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -167,7 +167,7 @@ pub fn _process_gpt<W: Write>(
         &rjiter_cell,
         &builder_cell,
         &scan_json::Options {
-            sse_tokens: sse_tokens,
+            sse_tokens,
             stop_early: false,
         },
     )?;

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -159,14 +159,17 @@ pub fn _process_gpt<W: Write>(
     );
     let triggers = make_triggers::<W>();
     let triggers_end = vec![end_message];
-    let sse_tokens = vec!["data:", "DONE"];
+    let sse_tokens = vec![String::from("data:"), String::from("DONE")];
 
     scan(
         &triggers,
         &triggers_end,
-        &sse_tokens,
         &rjiter_cell,
         &builder_cell,
+        &scan_json::Options {
+            sse_tokens: sse_tokens,
+            stop_early: false,
+        },
     )?;
     let mut builder = builder_cell.borrow_mut();
     builder.end_message()?;

--- a/ailets-rs/gpt/tests/handlers_test.rs
+++ b/ailets-rs/gpt/tests/handlers_test.rs
@@ -25,7 +25,7 @@ fn content_writes_to_builder() {
 
     // Assert
     assert!(matches!(result, StreamOp::ValueIsConsumed));
-    let expected = r#"{"type":"ctl","role":"assistant"}
+    let expected = r#"[{"type":"ctl"},{"role":"assistant"}]
 [{"type":"text"},{"text":"hello world"#;
     assert_eq!(writer.get_output(), expected);
 }

--- a/ailets-rs/gpt/tests/structure_builder_test.rs
+++ b/ailets-rs/gpt/tests/structure_builder_test.rs
@@ -17,7 +17,7 @@ fn basic_pass() {
     builder.end_message().unwrap();
 
     // Assert
-    let expected = r#"{"type":"ctl","role":"assistant"}
+    let expected = r#"[{"type":"ctl"},{"role":"assistant"}]
 [{"type":"text"},{"text":"hello"}]
 "#
     .to_owned();
@@ -37,7 +37,7 @@ fn create_message_without_input_role() {
     builder.end_message().unwrap();
 
     // Assert
-    let expected = r#"{"type":"ctl","role":"assistant"}
+    let expected = r#"[{"type":"ctl"},{"role":"assistant"}]
 [{"type":"text"},{"text":"hello"}]
 "#
     .to_owned();
@@ -59,7 +59,7 @@ fn can_call_end_message_multiple_times() {
     builder.end_message().unwrap(); // Should be ok
 
     // Assert
-    let expected = r#"{"type":"ctl","role":"assistant"}
+    let expected = r#"[{"type":"ctl"},{"role":"assistant"}]
 [{"type":"text"},{"text":"hello"}]
 "#
     .to_owned();

--- a/ailets-rs/messages_to_markdown/Cargo.toml
+++ b/ailets-rs/messages_to_markdown/Cargo.toml
@@ -15,4 +15,4 @@ actor_io = { version = "0.1.0", path = "../actor_io" }
 actor_runtime = { version = "0.2.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 getrandom = { version = "0.2", features = ["custom"] }
-scan_json = "1.0.2"
+scan_json = "1.1.0"

--- a/ailets-rs/messages_to_markdown/src/lib.rs
+++ b/ailets-rs/messages_to_markdown/src/lib.rs
@@ -72,7 +72,7 @@ pub fn _messages_to_markdown<W: Write>(
         Box::new(on_content_text) as BA<'_, W>,
     );
 
-    scan(&[content_text], &[], &[], &rjiter_cell, &builder_cell)?;
+    scan(&[content_text], &[], &rjiter_cell, &builder_cell, &scan_json::Options::default())?;
     builder_cell.borrow_mut().finish_with_newline()?;
     Ok(())
 }

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 
 [lib]
 # To run tests, two types are needed
-# crate-type = ["cdylib", "lib"]
-crate-type = ["lib"]
+crate-type = ["cdylib", "lib"]
+# crate-type = ["lib"]
 
 [dependencies]
 actor_io = { version = "0.1.0", path = "../actor_io" }

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -16,10 +16,10 @@ actor_runtime = { version = "0.2.0", path = "../actor_runtime" }
 actor_runtime_mocked = { version = "0.1.0", path = "../actor_runtime_mocked" }
 serde_json = "1.0.140"
 getrandom = { version = "0.2", features = ["custom"] }
-scan_json = { version = "1.0.3", path = "../../../streaming_json/scan_json" }
 serde = { version = "1.0.219", features = ["derive"] }
 base64 = "0.22.1"
 linked-hash-map = "0.5.6"
+scan_json = "1.1.0"
 
 [dev-dependencies]
 hamcrest = "0.1.5"

--- a/ailets-rs/messages_to_query/Cargo.toml
+++ b/ailets-rs/messages_to_query/Cargo.toml
@@ -7,8 +7,8 @@ license.workspace = true
 
 [lib]
 # To run tests, two types are needed
-crate-type = ["cdylib", "lib"]
-# crate-type = ["cdylib"]
+# crate-type = ["cdylib", "lib"]
+crate-type = ["lib"]
 
 [dependencies]
 actor_io = { version = "0.1.0", path = "../actor_io" }

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -1,4 +1,5 @@
 use crate::structure_builder::StructureBuilder;
+use scan_json::idtransform::idtransform;
 use scan_json::rjiter::jiter::Peek;
 use scan_json::RJiter;
 use scan_json::StreamOp;
@@ -271,6 +272,26 @@ pub fn on_func_arguments<W: Write>(
         return StreamOp::Error(e.into());
     }
     if let Err(e) = builder.end_function_arguments() {
+        return StreamOp::Error(e.into());
+    }
+
+    StreamOp::ValueIsConsumed
+}
+
+pub fn on_toolspec<W: Write>(
+    rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut builder = builder_cell.borrow_mut();
+
+    if let Err(e) = builder.begin_toolspec() {
+        return StreamOp::Error(e.into());
+    }
+    let writer = builder.get_writer();
+    if let Err(e) = idtransform(rjiter_cell, writer) {
+        return StreamOp::Error(e.into());
+    }
+    if let Err(e) = builder.end_toolspec() {
         return StreamOp::Error(e.into());
     }
 

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -65,7 +65,7 @@ pub fn on_item_type<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_item_text<W: Write>(
+pub fn on_text<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -101,7 +101,7 @@ pub fn on_item_text<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_item_image_url<W: Write>(
+pub fn on_image_url<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -137,7 +137,7 @@ pub fn on_item_image_url<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_item_image_key<W: Write>(
+pub fn on_image_key<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -156,7 +156,7 @@ pub fn on_item_image_key<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_item_attribute_content_type<W: Write>(
+pub fn on_image_content_type<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
@@ -177,7 +177,7 @@ pub fn on_item_attribute_content_type<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
-pub fn on_item_attribute_detail<W: Write>(
+pub fn on_image_detail<W: Write>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -288,7 +288,7 @@ where
 {
     let mut builder = builder_cell.borrow_mut();
 
-    if let Err(e) = builder.begin_toolspec() {
+    if let Err(e) = builder.begin_toolspec_function() {
         return StreamOp::Error(e.into());
     }
 
@@ -296,7 +296,7 @@ where
         return StreamOp::Error(e.into());
     }
 
-    if let Err(e) = builder.end_toolspec() {
+    if let Err(e) = builder.end_toolspec_function() {
         return StreamOp::Error(e.into());
     }
 
@@ -327,5 +327,5 @@ pub fn on_toolspec_key<W: Write>(
         }
     };
 
-    process_toolspec(builder_cell, |builder| builder.toolspec_key_internal(key))
+    process_toolspec(builder_cell, |builder| builder.toolspec_key(key))
 }

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -297,3 +297,22 @@ pub fn on_toolspec<W: Write>(
 
     StreamOp::ValueIsConsumed
 }
+
+pub fn on_toolspec_key<W: Write>(
+    rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut rjiter = rjiter_cell.borrow_mut();
+    let key = match rjiter.next_str() {
+        Ok(k) => k,
+        Err(e) => {
+            return StreamOp::Error(
+                format!("Error getting toolspec_key value. Expected string, got: {e:?}").into(),
+            );
+        }
+    };
+    if let Err(e) = builder_cell.borrow_mut().toolspec_key(key) {
+        return StreamOp::Error(e.into());
+    }
+    StreamOp::ValueIsConsumed
+}

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -210,7 +210,10 @@ pub fn on_func_id<W: Write>(
             );
         }
     };
-    if let Err(e) = builder_cell.borrow_mut().func_id(id) {
+    if let Err(e) = builder_cell
+        .borrow_mut()
+        .add_item_attribute(String::from("id"), String::from(id))
+    {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed
@@ -229,7 +232,10 @@ pub fn on_func_name<W: Write>(
             );
         }
     };
-    if let Err(e) = builder_cell.borrow_mut().func_name(name) {
+    if let Err(e) = builder_cell
+        .borrow_mut()
+        .add_item_attribute(String::from("name"), String::from(name))
+    {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed
@@ -257,14 +263,14 @@ pub fn on_func_arguments<W: Write>(
 
     let mut builder = builder_cell.borrow_mut();
 
-    if let Err(e) = builder.begin_arguments() {
+    if let Err(e) = builder.begin_function_arguments() {
         return StreamOp::Error(e.into());
     }
     let writer = builder.get_writer();
     if let Err(e) = rjiter.write_long_bytes(writer) {
         return StreamOp::Error(e.into());
     }
-    if let Err(e) = builder.end_arguments() {
+    if let Err(e) = builder.end_function_arguments() {
         return StreamOp::Error(e.into());
     }
 

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -67,17 +67,11 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         Box::new(handlers::on_item_attribute_detail) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let func_id = Trigger::new(
-        Box::new(ParentAndName::new(
-            "#array".to_string(),
-            "id".to_string(),
-        )),
+        Box::new(ParentAndName::new("#array".to_string(), "id".to_string())),
         Box::new(handlers::on_func_id) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let func_name = Trigger::new(
-        Box::new(ParentAndName::new(
-            "#array".to_string(),
-            "name".to_string(),
-        )),
+        Box::new(ParentAndName::new("#array".to_string(), "name".to_string())),
         Box::new(handlers::on_func_name) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let func_arguments = Trigger::new(

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -52,19 +52,40 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         )),
         Box::new(handlers::on_item_image_key) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let attr_content_type = Trigger::new(
+    let image_content_type = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "content_type".to_string(),
         )),
         Box::new(handlers::on_item_attribute_content_type) as BoxedAction<'_, StructureBuilder<W>>,
     );
-    let attr_detail = Trigger::new(
+    let image_detail = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "detail".to_string(),
         )),
         Box::new(handlers::on_item_attribute_detail) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let func_id = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#array".to_string(),
+            "id".to_string(),
+        )),
+        Box::new(handlers::on_item_attribute_id) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let func_name = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#array".to_string(),
+            "name".to_string(),
+        )),
+        Box::new(handlers::on_item_attribute_name) as BoxedAction<'_, StructureBuilder<W>>,
+    );
+    let func_arguments = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#array".to_string(),
+            "arguments".to_string(),
+        )),
+        Box::new(handlers::on_item_attribute_arguments) as BoxedAction<'_, StructureBuilder<W>>,
     );
 
     vec![
@@ -73,8 +94,11 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         image_url,
         image_key,
         item,
-        attr_content_type,
-        attr_detail,
+        image_content_type,
+        image_detail,
+        func_id,
+        func_name,
+        func_arguments,
         role,
     ]
 }

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -81,6 +81,13 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         )),
         Box::new(handlers::on_func_arguments) as BoxedAction<'_, StructureBuilder<W>>,
     );
+    let toolspec = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#array".to_string(),
+            "toolspec".to_string(),
+        )),
+        Box::new(handlers::on_toolspec) as BoxedAction<'_, StructureBuilder<W>>,
+    );
 
     vec![
         item_type,
@@ -93,6 +100,7 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         func_id,
         func_name,
         func_arguments,
+        toolspec,
         role,
     ]
 }

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -133,9 +133,9 @@ pub fn _process_query<W: Write>(
     scan(
         &begin_triggers,
         &end_triggers,
-        &[],
         &rjiter_cell,
         &builder_cell,
+        &scan_json::Options::default(),
     )?;
     builder_cell.borrow_mut().end()?;
     Ok(())

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -71,21 +71,21 @@ fn create_begin_triggers<'a, W: Write + 'a>(
             "#array".to_string(),
             "id".to_string(),
         )),
-        Box::new(handlers::on_item_attribute_id) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_func_id) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let func_name = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "name".to_string(),
         )),
-        Box::new(handlers::on_item_attribute_name) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_func_name) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let func_arguments = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "arguments".to_string(),
         )),
-        Box::new(handlers::on_item_attribute_arguments) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_func_arguments) as BoxedAction<'_, StructureBuilder<W>>,
     );
 
     vec![

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -88,6 +88,13 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         )),
         Box::new(handlers::on_toolspec) as BoxedAction<'_, StructureBuilder<W>>,
     );
+    let toolspec_key = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#array".to_string(),
+            "toolspec_key".to_string(),
+        )),
+        Box::new(handlers::on_toolspec_key) as BoxedAction<'_, StructureBuilder<W>>,
+    );
 
     vec![
         item_type,
@@ -101,6 +108,7 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         func_name,
         func_arguments,
         toolspec,
+        toolspec_key,
         role,
     ]
 }

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -125,7 +125,7 @@ fn create_end_triggers<'a, W: Write + 'a>(
 
 /// # Errors
 /// If anything goes wrong.
-pub fn _process_query<W: Write>(
+pub fn _process_messages<W: Write>(
     mut reader: impl std::io::Read,
     writer: W,
     env_opts: EnvOpts,
@@ -152,7 +152,7 @@ pub fn _process_query<W: Write>(
 /// # Panics
 /// If anything goes wrong.
 #[no_mangle]
-pub extern "C" fn process_query() -> *const c_char {
+pub extern "C" fn process_messages() -> *const c_char {
     let reader = AReader::new_from_std(StdHandle::Stdin);
     let writer = AWriter::new_from_std(StdHandle::Stdout);
 
@@ -167,7 +167,7 @@ pub extern "C" fn process_query() -> *const c_char {
         }
     };
 
-    if let Err(e) = _process_query(reader, writer, env_opts) {
+    if let Err(e) = _process_messages(reader, writer, env_opts) {
         return err_to_heap_c_string(extract_errno(&e), &format!("Messages to query: {e}"));
     }
     std::ptr::null()

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -36,35 +36,35 @@ fn create_begin_triggers<'a, W: Write + 'a>(
     //
     let text = Trigger::new(
         Box::new(ParentAndName::new("#array".to_string(), "text".to_string())),
-        Box::new(handlers::on_item_text) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_text) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let image_url = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "image_url".to_string(),
         )),
-        Box::new(handlers::on_item_image_url) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_image_url) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let image_key = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "image_key".to_string(),
         )),
-        Box::new(handlers::on_item_image_key) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_image_key) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let image_content_type = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "content_type".to_string(),
         )),
-        Box::new(handlers::on_item_attribute_content_type) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_image_content_type) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let image_detail = Trigger::new(
         Box::new(ParentAndName::new(
             "#array".to_string(),
             "detail".to_string(),
         )),
-        Box::new(handlers::on_item_attribute_detail) as BoxedAction<'_, StructureBuilder<W>>,
+        Box::new(handlers::on_image_detail) as BoxedAction<'_, StructureBuilder<W>>,
     );
     let func_id = Trigger::new(
         Box::new(ParentAndName::new("#array".to_string(), "id".to_string())),

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -97,6 +97,9 @@ impl<W: Write> StructureBuilder<W> {
     // - foo: end the level "foo"
     //
 
+    // Never call `end_item` to avoid infinite recursion.
+    // Let it be the responsibility of the client.
+
     /// # Errors
     /// I/O
     pub fn end(&mut self) -> Result<(), String> {
@@ -130,7 +133,7 @@ impl<W: Write> StructureBuilder<W> {
                 ))
             }
             Divider::ItemCommaToolspecs => {
-                self.end_item()?;
+                // not: self.end_item()?;
             }
         }
         self.writer.write_all(b"] ").map_err(|e| e.to_string())?;
@@ -165,12 +168,12 @@ impl<W: Write> StructureBuilder<W> {
                 ))
             }
             Divider::ItemCommaContent => {
-                self.end_item()?;
+                // not: self.end_item()?;
                 // Close the content array
                 self.writer.write_all(b"\n]").map_err(|e| e.to_string())?;
             }
             Divider::ItemCommaFunctions => {
-                self.end_item()?;
+                // not: self.end_item()?;
                 // Close the tool_calls array
                 self.writer.write_all(b"\n]").map_err(|e| e.to_string())?;
             }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -25,6 +25,12 @@ impl serde_json::ser::Formatter for StrFormatter {
     }
 }
 
+//
+// The state machine, to generate on the levels:
+// top -> messages -> message with role -> content -> content item
+// top -> messages -> message with role -> tool_calls -> function call item
+// top -> tools -> toolspec item
+//
 #[derive(Debug, PartialEq)]
 pub enum Divider {
     Prologue, // Need to write the prologue, then start "messages" or "tools"

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -332,6 +332,8 @@ impl<W: Write> StructureBuilder<W> {
         let item_type = attrs
             .get("type")
             .ok_or_else(|| "Missing 'type' attribute".to_string())?;
+        let is_function = item_type == "function";
+        let is_toolspec = item_type == "toolspec";
         let item_type = match item_type.as_str() {
             "image" => "image_url",
             "toolspec" => "function",
@@ -339,8 +341,6 @@ impl<W: Write> StructureBuilder<W> {
         };
 
         // Step 2: Begin section
-        let is_function = item_type == "function";
-        let is_toolspec = item_type == "toolspec";
         self.divider =
             Self::maybe_begin_section(&mut self.writer, &self.divider, is_function, is_toolspec)?;
 
@@ -572,15 +572,13 @@ impl<W: Write> StructureBuilder<W> {
         self.really_begin_item()?;
 
         self.writer
-            .write_all(b"\"function\":{")
+            .write_all(b",\"function\":")
             .map_err(|e| e.to_string())?;
         Ok(())
     }
 
     /// # Errors
-    /// - I/O
     pub fn end_toolspec(&mut self) -> Result<(), String> {
-        self.writer.write_all(b"}").map_err(|e| e.to_string())?;
         Ok(())
     }
 }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -372,8 +372,8 @@ impl<W: Write> StructureBuilder<W> {
     fn want_toolspecs(&mut self) -> Result<(), String> {
         match self.divider {
             Divider::ItemCommaToolspecs => {
-                // Already in tools section, add comma for next toolspec
-                self.writer.write_all(b",").map_err(|e| e.to_string())?;
+                // Already in tools section, add comma and newline for next toolspec
+                self.writer.write_all(b",\n").map_err(|e| e.to_string())?;
                 return Ok(());
             }
             Divider::MessageComma

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -387,7 +387,7 @@ impl<W: Write> StructureBuilder<W> {
             }
         }
         self.writer
-            .write_all(b", \"tools\": [")
+            .write_all(b",\n\"tools\": [")
             .map_err(|e| e.to_string())?;
         self.divider = Divider::ItemCommaToolspecs;
         Ok(())
@@ -401,13 +401,13 @@ impl<W: Write> StructureBuilder<W> {
             // First item in message, "content" or "tool_calls"
             (Divider::ItemNone, false) => {
                 self.writer
-                    .write_all(b",\"content\":[\n")
+                    .write_all(b",\n\"content\":[\n")
                     .map_err(|e| e.to_string())?;
                 self.divider = Divider::ItemCommaContent;
             }
             (Divider::ItemNone, true) => {
                 self.writer
-                    .write_all(b",\"tool_calls\":[\n")
+                    .write_all(b",\n\"tool_calls\":[\n")
                     .map_err(|e| e.to_string())?;
                 self.divider = Divider::ItemCommaFunctions;
             }
@@ -419,7 +419,7 @@ impl<W: Write> StructureBuilder<W> {
             (Divider::ItemCommaContent, true) => {
                 self.writer.write_all(b"]").map_err(|e| e.to_string())?;
                 self.writer
-                    .write_all(b",\"tool_calls\":[\n")
+                    .write_all(b",\n\"tool_calls\":[\n")
                     .map_err(|e| e.to_string())?;
                 self.divider = Divider::ItemCommaFunctions;
             }
@@ -427,7 +427,7 @@ impl<W: Write> StructureBuilder<W> {
             (Divider::ItemCommaFunctions, false) => {
                 self.writer.write_all(b"]").map_err(|e| e.to_string())?;
                 self.writer
-                    .write_all(b",\"content\":[\n")
+                    .write_all(b",\n\"content\":[\n")
                     .map_err(|e| e.to_string())?;
                 self.divider = Divider::ItemCommaContent;
             }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -391,19 +391,22 @@ impl<W: Write> StructureBuilder<W> {
                 self.writer.write_all(b",\n").map_err(|e| e.to_string())?;
             }
             // The very beginning, write message content/function section
+            // Assume that the attribute `role` has been written already, therefore add a comma
             (Divider::ItemNone, false) => {
                 self.writer
-                    .write_all(b"\"content\":[\n")
+                    .write_all(b",\n\"content\":[\n")
                     .map_err(|e| e.to_string())?;
+                self.divider = Divider::ItemCommaContent;
             }
             (Divider::ItemNone, true) => {
                 self.writer
-                    .write_all(b"\"tool_calls\":[\n")
+                    .write_all(b",\n\"tool_calls\":[\n")
                     .map_err(|e| e.to_string())?;
+                self.divider = Divider::ItemCommaFunctions;
             }
             // Switch between "content" to "tool_calls"
             (Divider::ItemCommaContent, true) | (Divider::ItemCommaFunctions, false) => {
-                self.writer.write_all(b",\n").map_err(|e| e.to_string())?;
+                self.writer.write_all(b"]").map_err(|e| e.to_string())?;
                 self.divider = Divider::ItemNone;
                 self.want_message_item(is_function)?;
             }

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -373,6 +373,9 @@ impl<W: Write> StructureBuilder<W> {
             .and_then(|attrs| attrs.get("type"))
             .map_or(true, |t| t == "ctl");
         if !is_ctl {
+            if self.item_attr_mode == ItemAttrMode::Collect {
+                self.really_begin_item()?;
+            }
             self.writer.write_all(b"}").map_err(|e| e.to_string())?;
         }
 

--- a/ailets-rs/messages_to_query/src/structure_builder.rs
+++ b/ailets-rs/messages_to_query/src/structure_builder.rs
@@ -473,7 +473,7 @@ impl<W: Write> StructureBuilder<W> {
             if key == "type" {
                 continue;
             }
-            if item_type == "image_url" && (key == "detail" || key == "content_type") {
+            if item_type == "image" && (key == "detail" || key == "content_type") {
                 continue;
             }
             write!(self.writer, r#","{key}":"#).map_err(|e| e.to_string())?;

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -133,7 +133,7 @@ fn function_call() {
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
-    let expected_item = r#"[{"role":"assistant","content":null,"tool_calls": [
+    let expected_item = r#"[{"role":"assistant","tool_calls": [
         {"id":"id123","type":"function","function":{"name":"get_weather","arguments":"{\"location\": \"London\", \"unit\": \"celsius\"}"}}
     ]}]"#;
     let expected_json = serde_json::from_str(wrap_boilerplate(&expected_item).as_str())

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -22,6 +22,13 @@ fn wrap_boilerplate(s: &str) -> String {
     format!("{}\n{}\n{}\n{}{}{}", s1, s2, s3, s4, s, s_end)
 }
 
+fn inject_tools(payload: &str, tools: &str) -> String {
+    payload.replace(
+        r#""messages": ["#,
+        &format!(r#""tools": {},"messages": ["#, tools),
+    )
+}
+
 #[test]
 fn test_text_items() {
     let fixture_content = std::fs::read_to_string("tests/fixture/text_items.txt")
@@ -221,12 +228,12 @@ fn tool_specification() {
         r#"[{{"type":"function","function":{}}},{{"type":"function","function":{}}}]"#,
         get_user_name_function, another_function
     );
-    let expected_item = format!(
-        r#"[{{"role":"user","tools":{expected_tools},"content":[{{"type":"text","text":"Hello!"}}]}}]"#
-    );
+    let expected_item =
+        format!(r#"[{{"role":"user","content":[{{"type":"text","text":"Hello!"}}]}}]"#);
     let expected = wrap_boilerplate(&expected_item);
-    let expected_json =
-        serde_json::from_str(&expected).expect("Failed to parse expected output as JSON");
+    let expected_with_tools = inject_tools(&expected, &expected_tools);
+    let expected_json = serde_json::from_str(&expected_with_tools)
+        .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
 
@@ -262,9 +269,10 @@ fn toolspec_by_key() {
         .expect("Failed to parse output as JSON");
 
     let expected_tools = format!(r#"[{{"type":"function","function":{}}}]"#, toolspec_content);
-    let expected_item = format!(r#"[{{"role":"user","tools":{expected_tools}}}]"#);
+    let expected_item = format!(r#"[{{"role":"user","content":[]}}]"#);
     let expected = wrap_boilerplate(&expected_item);
-    let expected_json =
-        serde_json::from_str(&expected).expect("Failed to parse expected output as JSON");
+    let expected_with_tools = inject_tools(&expected, &expected_tools);
+    let expected_json = serde_json::from_str(&expected_with_tools)
+        .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -193,9 +193,7 @@ fn special_symbols_in_function_arguments() {
 
 #[test]
 fn tool_specification() {
-    let input = r#"[{"type": "ctl"}, {"role": "user"}]
-                   [{"type": "text"}, {"text": "Hello!"}]"#;
-    let tools_input = r#"{
+    let tools = r#"{
         "name": "get_user_name",
         "description": "Get the user's name. Call this whenever you need to know the name of the user.",
         "strict": true,
@@ -208,18 +206,15 @@ fn tool_specification() {
     {
         "name": "another_function", "foo": "bar"
     }"#;
+    let input = r#"[{"type": "ctl"}, {"role": "user"}]
+                   [{"type": "tools"}, _TOOLS_]
+                   [{"type": "text"}, {"text": "Hello!"}]"#;
+    let input = input.replace("_TOOLS_", &tools);
+
     let reader = Cursor::new(input);
-    let tools_reader = Cursor::new(tools_input);
     let writer = RcWriter::new();
 
-    _process_query(
-        reader,
-        tools_reader,
-        writer.clone(),
-        create_empty_env_opts(),
-    )
-    .unwrap();
-    println!("!!! output {}", writer.get_output().as_str()); // FIXME
+    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -2,7 +2,7 @@
 extern crate hamcrest;
 use actor_runtime_mocked::{add_file, RcWriter};
 use hamcrest::prelude::*;
-use messages_to_query::_process_query;
+use messages_to_query::_process_messages;
 use messages_to_query::env_opts::EnvOpts;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -36,7 +36,7 @@ fn test_text_items() {
     let reader = Cursor::new(fixture_content.clone());
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -60,7 +60,7 @@ fn special_symbols_in_text() {
     let reader = Cursor::new(input);
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -81,7 +81,7 @@ fn image_url_as_is() {
     let reader = Cursor::new(input);
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -100,7 +100,7 @@ fn image_as_key() {
     let writer = RcWriter::new();
     add_file(String::from("media/image-as-key-2.png"), b"hello".to_vec());
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -119,7 +119,7 @@ fn mix_text_and_image() {
     let reader = Cursor::new(input);
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -142,7 +142,7 @@ fn regression_one_item_not_two() {
     let reader = Cursor::new(input);
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -160,7 +160,7 @@ fn function_call() {
     let reader = Cursor::new(input);
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -180,7 +180,7 @@ fn special_symbols_in_function_arguments() {
     let reader = Cursor::new(input);
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -220,7 +220,7 @@ fn tool_specification() {
     let reader = Cursor::new(input);
     let writer = RcWriter::new();
 
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -262,7 +262,7 @@ fn toolspec_by_key() {
     let writer = RcWriter::new();
 
     // Act
-    _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
 
     // Assert
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -211,10 +211,10 @@ fn tool_specification() {
     }"#;
 
     let input = format!(
-        r#"[{{"type": "ctl"}}, {{"role": "user"}}]
-                   [{{"type": "toolspec"}}, {{"toolspec": {get_user_name_function}}}]
-                   [{{"type": "toolspec"}}, {{"toolspec": {another_function}}}]
-                   [{{"type": "text"}}, {{"text": "Hello!"}}]"#
+        r#"[{{"type": "toolspec"}}, {{"toolspec": {get_user_name_function}}}]
+           [{{"type": "toolspec"}}, {{"toolspec": {another_function}}}]
+           [{{"type": "ctl"}}, {{"role": "user"}}]
+           [{{"type": "text"}}, {{"text": "Hello!"}}]"#
     );
 
     let reader = Cursor::new(input);
@@ -253,10 +253,9 @@ fn toolspec_by_key() {
         String::from("tools/get_user_name.json"),
         toolspec_content.as_bytes().to_vec(),
     );
-    let input = format!(
-        r#"[{{"type": "toolspec"}}, {{"toolspec_key": "tools/get_user_name.json"}}]
-           [{{"type": "ctl"}}, {{"role": "user"}}]"#
-    );
+    let input = r#"[{"type": "toolspec"}, {"toolspec_key": "tools/get_user_name.json"}]
+           [{"type": "ctl"}, {"role": "user"}]
+           "#;
 
     let reader = Cursor::new(input);
     let writer = RcWriter::new();

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -24,7 +24,7 @@ fn wrap_boilerplate(s: &str, tools: Option<&str>) -> String {
     let s4 = s4.replace("_TOOLS_", &tools);
     let s_end = "}}\n";
     let s = s.replace("_NL_", "\n");
-    format!("{}\n{}\n{}\n{}{}{}{}", s1, s2, s3, s4, tools, s, s_end)
+    format!("{}\n{}\n{}\n{}{}{}", s1, s2, s3, s4, s, s_end)
 }
 
 #[test]

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -214,7 +214,6 @@ fn tool_specification() {
     let writer = RcWriter::new();
 
     _process_query(reader, writer.clone(), create_empty_env_opts()).unwrap();
-    println!("output: {}", writer.get_output()); // FIXME
     let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
@@ -223,7 +222,7 @@ fn tool_specification() {
         get_user_name_function, another_function
     );
     let expected_item = format!(
-        r#"[{{"role":"user","tools":[{expected_tools}],"content":[{{"type":"text","text":"Hello!"}}]}}]"#
+        r#"[{{"role":"user","tools":{expected_tools},"content":[{{"type":"text","text":"Hello!"}}]}}]"#
     );
     let expected = wrap_boilerplate(&expected_item);
     let expected_json =

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -254,8 +254,8 @@ fn toolspec_by_key() {
         toolspec_content.as_bytes().to_vec(),
     );
     let input = format!(
-        r#"[{{"type": "ctl"}}, {{"role": "user"}}]
-           [{{"type": "toolspec"}}, {{"toolspec_key": "tools/get_user_name.json"}}]"#
+        r#"[{{"type": "toolspec"}}, {{"toolspec_key": "tools/get_user_name.json"}}]
+           [{{"type": "ctl"}}, {{"role": "user"}}]"#
     );
 
     let reader = Cursor::new(input);
@@ -269,7 +269,7 @@ fn toolspec_by_key() {
         .expect("Failed to parse output as JSON");
 
     let expected_tools = format!(r#"[{{"type":"function","function":{}}}]"#, toolspec_content);
-    let expected_item = format!(r#"[{{"role":"user","content":[]}}]"#);
+    let expected_item = format!(r#"[{{"role":"user"}}]"#);
     let expected = wrap_boilerplate(&expected_item);
     let expected_with_tools = inject_tools(&expected, &expected_tools);
     let expected_json = serde_json::from_str(&expected_with_tools)

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -100,27 +100,6 @@ fn many_messages_and_items() {
     assert_that!(writer.get_output(), equal_to(expected));
 }
 
-#[test]
-fn skip_empty_items_but_create_content_wrapper() {
-    let writer = RcWriter::new();
-    let builder = StructureBuilder::new(writer.clone(), create_empty_env_opts());
-    let mut builder = builder;
-
-    begin_message(&mut builder, "user");
-    builder.begin_item().unwrap();
-    builder.end_item().unwrap();
-
-    begin_message(&mut builder, "user");
-    builder.begin_item().unwrap();
-    builder.end_item().unwrap();
-    builder.begin_item().unwrap();
-    builder.end_item().unwrap();
-    builder.end().unwrap();
-
-    let empty_msg = "{\"role\":\"user\",\"content\":[]}".to_owned();
-    let two_empty_msgs = wrap_boilerplate(format!("{},{}", empty_msg, empty_msg).as_str());
-    assert_that!(writer.get_output(), equal_to(two_empty_msgs));
-}
 
 #[test]
 fn several_contentless_roles_create_several_messages_anyway() {
@@ -134,10 +113,10 @@ fn several_contentless_roles_create_several_messages_anyway() {
     begin_message(&mut builder, "tool");
     builder.end().unwrap();
 
-    let msg_user = r#"{"role":"user","content":[]}"#;
-    let msg_assistant = r#"{"role":"assistant","content":[]}"#;
-    let msg_tool = r#"{"role":"tool","content":[]}"#;
-    let msg_user2 = r#"{"role":"user","content":[]}"#;
+    let msg_user = r#"{"role":"user"}"#;
+    let msg_assistant = r#"{"role":"assistant"}"#;
+    let msg_tool = r#"{"role":"tool"}"#;
+    let msg_user2 = r#"{"role":"user"}"#;
     let expected = wrap_boilerplate(&format!(
         "{},{},{},{}",
         msg_user, msg_assistant, msg_user2, msg_tool

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -59,7 +59,7 @@ fn happy_path_for_text() {
     assert_that!(
         writer.get_output(),
         equal_to(wrap_boilerplate(
-            r#"{"role":"user","content":[_NL_{"type":"text","text":"Hello!"}_NL_]}"#
+            r#"{"role":"user",_NL_"content":[_NL_{"type":"text","text":"Hello!"}_NL_]}"#
         ))
     );
 }
@@ -94,7 +94,7 @@ fn many_messages_and_items() {
     let text_item2a = r#"{"type":"text","text":"First item of the second message"}"#;
     let text_item2b = r#"{"type":"text","text":"Second item of the second message"}"#;
     let expected = String::from(
-            r#"{"role":"user","content":[_NL__TI1__NL_]},{"role":"assistant","content":[_NL__TI2a_,_NL__TI2b__NL_]}"#
+            r#"{"role":"user",_NL_"content":[_NL__TI1__NL_]},{"role":"assistant",_NL_"content":[_NL__TI2a_,_NL__TI2b__NL_]}"#
         ).replace("_TI1_", text_item1).replace("_TI2a_", text_item2a).replace("_TI2b_", text_item2b);
     let expected = wrap_boilerplate(expected.as_str());
     assert_that!(writer.get_output(), equal_to(expected));
@@ -155,8 +155,9 @@ fn auto_generate_type_text() {
     builder.end_item().unwrap();
     builder.end().unwrap();
 
-    let expected =
-        wrap_boilerplate(r#"{"role":"user","content":[_NL_{"type":"text","text":"hello"}_NL_]}"#);
+    let expected = wrap_boilerplate(
+        r#"{"role":"user",_NL_"content":[_NL_{"type":"text","text":"hello"}_NL_]}"#,
+    );
     assert_that!(writer.get_output(), equal_to(expected));
 }
 
@@ -232,7 +233,7 @@ fn support_special_chars_and_unicode() {
 
     let expected = wrap_boilerplate(
         format!(
-            r#"{{"role":"user","content":[_NL_{{"type":"text","text":"{}"}}_NL_]}}"#,
+            r#"{{"role":"user",_NL_"content":[_NL_{{"type":"text","text":"{}"}}_NL_]}}"#,
             special_chars
         )
         .as_str(),
@@ -270,7 +271,7 @@ fn pass_preceding_attributes_to_text_output() {
         writer.get_output(),
         equal_to(wrap_boilerplate(
             format!(
-                r#"{{"role":"user","content":[_NL_{}_NL_]}}"#,
+                r#"{{"role":"user",_NL_"content":[_NL_{}_NL_]}}"#,
                 expected_text_item
             )
             .as_str()
@@ -305,7 +306,7 @@ fn pass_following_attributes_to_text_output() {
         writer.get_output(),
         equal_to(wrap_boilerplate(
             format!(
-                r#"{{"role":"user","content":[_NL_{}_NL_]}}"#,
+                r#"{{"role":"user",_NL_"content":[_NL_{}_NL_]}}"#,
                 expected_text_item
             )
             .as_str()
@@ -341,7 +342,7 @@ fn add_image_by_url() {
         writer.get_output(),
         equal_to(wrap_boilerplate(
             format!(
-                r#"{{"role":"user","content":[_NL_{}_NL_]}}"#,
+                r#"{{"role":"user",_NL_"content":[_NL_{}_NL_]}}"#,
                 expected_image_item
             )
             .as_str()
@@ -377,7 +378,7 @@ fn add_image_by_key() {
         writer.get_output(),
         equal_to(wrap_boilerplate(
             format!(
-                r#"{{"role":"user","content":[_NL_{}_NL_]}}"#,
+                r#"{{"role":"user",_NL_"content":[_NL_{}_NL_]}}"#,
                 expected_image_item
             )
             .as_str()
@@ -441,7 +442,7 @@ fn add_image_with_detail() {
         writer.get_output(),
         equal_to(wrap_boilerplate(
             format!(
-                r#"{{"role":"user","content":[_NL_{}_NL_]}}"#,
+                r#"{{"role":"user",_NL_"content":[_NL_{}_NL_]}}"#,
                 expected_image_item
             )
             .as_str()
@@ -483,7 +484,7 @@ fn image_key_with_adversarial_content_type() {
         writer.get_output(),
         equal_to(wrap_boilerplate(
             format!(
-                r#"{{"role":"user","content":[_NL_{}_NL_]}}"#,
+                r#"{{"role":"user",_NL_"content":[_NL_{}_NL_]}}"#,
                 expected_image_item
             )
             .as_str()
@@ -541,7 +542,7 @@ fn image_settings_dont_transfer() {
         writer.get_output(),
         equal_to(wrap_boilerplate(
             format!(
-                r#"{{"role":"user","content":[_NL_{},_NL_{}_NL_]}}"#,
+                r#"{{"role":"user",_NL_"content":[_NL_{},_NL_{}_NL_]}}"#,
                 expected_image1, expected_image2
             )
             .as_str()
@@ -598,7 +599,7 @@ fn mix_text_and_image_content() {
         r#"_NL_{},_NL_{},_NL_{}_NL_"#,
         text_item1, image_item, text_item2
     );
-    let expected_message = format!(r#"{{"role":"user","content":[{}]}}"#, expected_content);
+    let expected_message = format!(r#"{{"role":"user",_NL_"content":[{}]}}"#, expected_content);
     assert_that!(
         writer.get_output(),
         equal_to(wrap_boilerplate(expected_message.as_str()))
@@ -628,7 +629,7 @@ fn function_call() {
     builder.end_item().unwrap();
     builder.end().unwrap();
 
-    let expected_item = r#"{"role":"assistant","tool_calls":[_NL_{"type":"function","id":"id123","function":{"name":"get_weather","arguments":"foo,bar"}}_NL_]}"#;
+    let expected_item = r#"{"role":"assistant",_NL_"tool_calls":[_NL_{"type":"function","id":"id123","function":{"name":"get_weather","arguments":"foo,bar"}}_NL_]}"#;
     assert_that!(
         writer.get_output(),
         equal_to(wrap_boilerplate(expected_item))
@@ -745,11 +746,11 @@ fn mix_content_and_tool_calls() {
         r#"{"type":"function","function":{"name":"get_date","arguments":"{\"format\":\"ISO\"}"}}"#;
 
     let msg1 = format!(
-        r#"{{"role":"assistant","content":[_NL_{},_NL_{}],"tool_calls":[_NL_{}_NL_]}}"#,
+        r#"{{"role":"assistant",_NL_"content":[_NL_{},_NL_{}],_NL_"tool_calls":[_NL_{}_NL_]}}"#,
         msg1_text1, msg1_text2, msg1_fn
     );
     let msg2 = format!(
-        r#"{{"role":"user","content":[_NL_{}],"tool_calls":[_NL_{},_NL_{}_NL_]}}"#,
+        r#"{{"role":"user",_NL_"content":[_NL_{}],_NL_"tool_calls":[_NL_{},_NL_{}_NL_]}}"#,
         msg2_text, msg2_fn1, msg2_fn2
     );
     let expected = format!("{},{}", msg1, msg2);
@@ -832,7 +833,7 @@ fn happy_path_toolspecs() {
     }}]"#
     );
     let expected_item =
-        format!(r#"{{"role":"user","content":[{{"type":"text","text":"Hello!"}}]}}"#);
+        format!(r#"{{"role":"user",_NL_"content":[{{"type":"text","text":"Hello!"}}]}}"#);
     let expected = wrap_boilerplate(&expected_item);
     let expected_with_tools = inject_tools(&expected, &expected_tools);
     let expected_json = serde_json::from_str(&expected_with_tools)
@@ -882,7 +883,8 @@ fn toolspec_by_key() {
         r#"{{ "url": "https://api.openai.com/v1/chat/completions",
 "method": "POST",
 "headers": {{ "Content-type": "application/json", "Authorization": "Bearer {{{{secret}}}}" }},
-"body": {{ "model": "gpt-4o-mini", "stream": true, "tools": {} }}}}
+"body": {{ "model": "gpt-4o-mini", "stream": true,
+"tools": {} }}}}
 "#,
         expected_tools
     );
@@ -1005,7 +1007,8 @@ fn several_toolspecs_to_one_block() {
         r#"{{ "url": "https://api.openai.com/v1/chat/completions",
 "method": "POST",
 "headers": {{ "Content-type": "application/json", "Authorization": "Bearer {{{{secret}}}}" }},
-"body": {{ "model": "gpt-4o-mini", "stream": true, "tools": {} }}}}
+"body": {{ "model": "gpt-4o-mini", "stream": true,
+"tools": {} }}}}
 "#,
         expected_tools
     );
@@ -1094,19 +1097,26 @@ fn mix_toolspec_and_other_content() {
         r#"[{{"type":"function","function":{}}}]"#,
         toolspec1_content
     );
-    let expected_message2 =
-        format!(r#"{{"role":"user","content":[{{"type":"text","text":"Some text content"}}]}}"#);
+    let expected_message2 = format!(
+        r#"{{"role":"user",
+"content":[
+{{"type":"text","text":"Some text content"}}
+]}}"#
+    );
     let expected_tools2 = format!(
         r#"[{{"type":"function","function":{}}}]"#,
         toolspec2_content
     );
     let expected_message3 = format!(
-        r#"{{"role":"user","tool_calls":[{{"type":"function","function":{{"name":"get_weather","arguments":"{{\"location\":\"London\"}}"}}}}]}}"#
+        r#"{{"role":"user",
+"tool_calls":[
+{{"type":"function","function":{{"name":"get_weather","arguments":"{{\"location\":\"London\"}}"}}}}
+]}}"#
     );
 
     // Concatenate all parts to build the expected output
     let expected_final = format!(
-        "{} \"messages\": [{}], \"tools\": {}, \"messages\": [{}], \"tools\": {}, \"messages\": [{}]}}}}",
+        "{} \"messages\": [{}],\n\"tools\": {}, \"messages\": [{}],\n\"tools\": {}, \"messages\": [{}]}}}}\n",
         prefix,
         expected_message1,
         expected_tools1,
@@ -1115,10 +1125,5 @@ fn mix_toolspec_and_other_content() {
         expected_message3
     );
 
-    // Compare after removing all whitespace
-    let strip_ws = |s: &str| s.chars().filter(|c| !c.is_whitespace()).collect::<String>();
-    assert_that!(
-        strip_ws(&actual_output),
-        equal_to(strip_ws(&expected_final))
-    );
+    assert_that!(actual_output, equal_to(expected_final));
 }

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -879,26 +879,22 @@ fn toolspec_by_key() {
 
     begin_message(&mut builder, "user");
     builder.begin_item().unwrap();
-
     builder
-        .add_item_attribute(String::from("type"), String::from("toolspec_key"))
+        .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
     builder.toolspec_key("tools/get_user_name.json").unwrap();
-
     builder.end_item().unwrap();
     builder.end().unwrap();
 
     let expected_toolspec_item =
         format!(r#"{{"type":"function","function":{}}}"#, toolspec_content);
+    let expected_output = format!(
+        r#"{{"role":"user","tools":[_NL_{}_NL_]}}"#,
+        expected_toolspec_item
+    );
     assert_that!(
         writer.get_output(),
-        equal_to(wrap_boilerplate(
-            format!(
-                r#"{{"role":"user","tools":[_NL_{}_NL_],"content":[]}}"#,
-                expected_toolspec_item
-            )
-            .as_str()
-        ))
+        equal_to(wrap_boilerplate(expected_output.as_str()))
     );
 }
 
@@ -910,9 +906,8 @@ fn toolspec_key_file_not_found() {
 
     begin_message(&mut builder, "user");
     builder.begin_item().unwrap();
-
     builder
-        .add_item_attribute(String::from("type"), String::from("toolspec_key"))
+        .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
 
     let result = builder.toolspec_key("tools/nonexistent.json");

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -30,8 +30,6 @@ fn create_empty_env_opts() -> EnvOpts {
     EnvOpts::from_map(HashMap::new())
 }
 
-
-
 fn begin_message(builder: &mut StructureBuilder<RcWriter>, role: &str) {
     builder.begin_item().unwrap();
     builder
@@ -1029,7 +1027,7 @@ fn mix_toolspec_and_other_content() {
 
     let toolspec1_content = r#"{"name":"tool1","description":"First tool"}"#;
     let toolspec2_content = r#"{"name":"tool2","description":"Second tool"}"#;
-    
+
     let mut cursor1 = Cursor::new(toolspec1_content.as_bytes().to_vec());
     let mut buffer1 = [0u8; 1024];
     let rjiter1 = scan_json::RJiter::new(&mut cursor1, &mut buffer1);

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -896,7 +896,7 @@ fn toolspec_by_key() {
     let expected_toolspec_item =
         format!(r#"{{"type":"function","function":{}}}"#, toolspec_content);
     let expected_tools = format!(r#"[_NL_{}_NL_]"#, expected_toolspec_item);
-    let expected_output = format!(r#"{{"role":"user","content":[]}}"#);
+    let expected_output = format!(r#"{{"role":"user"}}"#);
     let expected = wrap_boilerplate(expected_output.as_str());
     let expected_with_tools = inject_tools(&expected, &expected_tools);
     assert_that!(writer.get_output(), equal_to(expected_with_tools));

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -784,24 +784,24 @@ fn happy_path_toolspecs() {
     builder
         .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_toolspec().unwrap();
+    builder.begin_toolspec_function().unwrap();
     builder
         .get_writer()
         .write_all(get_user_name_fn.as_bytes())
         .unwrap();
-    builder.end_toolspec().unwrap();
+    builder.end_toolspec_function().unwrap();
     builder.end_item().unwrap();
 
     builder.begin_item().unwrap();
     builder
         .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_toolspec().unwrap();
+    builder.begin_toolspec_function().unwrap();
     builder
         .get_writer()
         .write_all(another_function_fn.as_bytes())
         .unwrap();
-    builder.end_toolspec().unwrap();
+    builder.end_toolspec_function().unwrap();
     builder.end_item().unwrap();
 
     begin_message(&mut builder, "user");
@@ -959,36 +959,36 @@ fn several_toolspecs_to_one_block() {
     builder
         .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_toolspec().unwrap();
+    builder.begin_toolspec_function().unwrap();
     builder
         .get_writer()
         .write_all(toolspec1_content.as_bytes())
         .unwrap();
-    builder.end_toolspec().unwrap();
+    builder.end_toolspec_function().unwrap();
     builder.end_item().unwrap();
 
     builder.begin_item().unwrap();
     builder
         .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_toolspec().unwrap();
+    builder.begin_toolspec_function().unwrap();
     builder
         .get_writer()
         .write_all(toolspec2_content.as_bytes())
         .unwrap();
-    builder.end_toolspec().unwrap();
+    builder.end_toolspec_function().unwrap();
     builder.end_item().unwrap();
 
     builder.begin_item().unwrap();
     builder
         .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_toolspec().unwrap();
+    builder.begin_toolspec_function().unwrap();
     builder
         .get_writer()
         .write_all(toolspec3_content.as_bytes())
         .unwrap();
-    builder.end_toolspec().unwrap();
+    builder.end_toolspec_function().unwrap();
     builder.end_item().unwrap();
 
     builder.end().unwrap();
@@ -1029,12 +1029,12 @@ fn mix_toolspec_and_other_content() {
     builder
         .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_toolspec().unwrap();
+    builder.begin_toolspec_function().unwrap();
     builder
         .get_writer()
         .write_all(toolspec1_content.as_bytes())
         .unwrap();
-    builder.end_toolspec().unwrap();
+    builder.end_toolspec_function().unwrap();
     builder.end_item().unwrap();
 
     // 3. some content: it should start "content"
@@ -1053,12 +1053,12 @@ fn mix_toolspec_and_other_content() {
     builder
         .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_toolspec().unwrap();
+    builder.begin_toolspec_function().unwrap();
     builder
         .get_writer()
         .write_all(toolspec2_content.as_bytes())
         .unwrap();
-    builder.end_toolspec().unwrap();
+    builder.end_toolspec_function().unwrap();
     builder.end_item().unwrap();
 
     // 5. a tool call item: it should start "tool_calls"

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -806,14 +806,26 @@ fn happy_path_toolspecs() {
 
     builder.begin_item().unwrap();
     builder
-        .add_item_attribute(String::from("type"), String::from("toolspecs"))
+        .add_item_attribute(String::from("type"), String::from("toolspec"))
         .unwrap();
-    builder.begin_text().unwrap();
+    builder.begin_toolspec().unwrap();
     builder
         .get_writer()
-        .write_all(format!("{}\n{}", get_user_name_fn, another_function_fn).as_bytes())
+        .write_all(get_user_name_fn.as_bytes())
         .unwrap();
-    builder.end_text().unwrap();
+    builder.end_toolspec().unwrap();
+    builder.end_item().unwrap();
+
+    builder.begin_item().unwrap();
+    builder
+        .add_item_attribute(String::from("type"), String::from("toolspec"))
+        .unwrap();
+    builder.begin_toolspec().unwrap();
+    builder
+        .get_writer()
+        .write_all(another_function_fn.as_bytes())
+        .unwrap();
+    builder.end_toolspec().unwrap();
     builder.end_item().unwrap();
 
     builder.begin_item().unwrap();

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -341,9 +341,8 @@ async def main() -> None:
     else:
         env = Environment(nodereg, kv=vfs)
         toml_to_env(env, model_opts, args.opt, toml=prompt)
-        toolspecs_to_dagops(env, args.tools)
-        await prompt_to_dagops(env, prompt=prompt)
-
+        tools_prompt = toolspecs_to_dagops(env, args.tools)
+        await prompt_to_dagops(env, prompt=list(tools_prompt) + list(prompt))
         model_node_name = instantiate_with_deps(env.dagops, nodereg, f".{model}", {})
         env.dagops.alias(".model_output", model_node_name)
 

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -31,6 +31,7 @@ from ailets.cons.flow_builder import (
     instantiate_with_deps,
     prompt_to_dagops,
     toml_to_env,
+    toolspecs_to_alias,
     toolspecs_to_dagops,
     dup_output_to_stdout,
 )
@@ -342,8 +343,14 @@ async def main() -> None:
         env = Environment(nodereg, kv=vfs)
         toml_to_env(env, model_opts, args.opt, toml=prompt)
         tools_prompt = toolspecs_to_dagops(env, args.tools)
+        tools_alias = toolspecs_to_alias(env, tools_prompt)
         await prompt_to_dagops(env, prompt=list(tools_prompt) + list(prompt))
-        model_node_name = instantiate_with_deps(env.dagops, nodereg, f".{model}", {})
+        model_node_name = instantiate_with_deps(
+            env.dagops,
+            nodereg,
+            f".{model}",
+            {".chat_messages.toolspecs": tools_alias},
+        )
         env.dagops.alias(".model_output", model_node_name)
 
         target_node_name = instantiate_with_deps(

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -29,6 +29,8 @@ from ailets.cons.plugin import (
 from ailets.cons.flow_builder import (
     CmdlinePromptItem,
     instantiate_with_deps,
+    media_to_alias,
+    media_to_dagops,
     prompt_to_dagops,
     toml_to_env,
     toolspecs_to_alias,
@@ -344,12 +346,17 @@ async def main() -> None:
         toml_to_env(env, model_opts, args.opt, toml=prompt)
         tools_prompt = toolspecs_to_dagops(env, args.tools)
         tools_alias = toolspecs_to_alias(env, tools_prompt)
-        await prompt_to_dagops(env, prompt=list(tools_prompt) + list(prompt))
+        media_ref_prompt = media_to_dagops(env, prompt)
+        media_alias = media_to_alias(env, media_ref_prompt)
+        await prompt_to_dagops(env, prompt=list(tools_prompt) + list(media_ref_prompt))
         model_node_name = instantiate_with_deps(
             env.dagops,
             nodereg,
             f".{model}",
-            {".chat_messages.toolspecs": tools_alias},
+            {
+                ".chat_messages.toolspecs": tools_alias,
+                ".chat_messages.media": media_alias,
+            },
         )
         env.dagops.alias(".model_output", model_node_name)
 

--- a/docs/content-typedef.md
+++ b/docs/content-typedef.md
@@ -87,3 +87,17 @@ Affect the processing of the following items. Currently, its main use is to anno
 - `[1].role: "system"|"user"|"assistant"|"tool"|str`
 
 See also [OpenAI chat completion messages](https://platform.openai.com/docs/api-reference/chat/create).
+
+
+## `ContentItemToolSpecs`
+
+Create a `tools` section to inform the LLM about what it can use. See the OpenAI documentation on [function calling](https://platform.openai.com/docs/guides/function-calling) for details.
+
+- `[0].type: "toolspecs"`
+- Either of, but not both:
+  - `[1].toolspecs: FunctionSpec[]`, or
+  - `[1].toolspecs_key: str`
+
+For `toolspecs`, the value is an array of function specifications in the OpenAI format.
+
+For `toolspecs_key`, the function specifications are read from the given key. The format is extended JSONL: instead of being wrapped in an array, the objects are immediately on the top level and _not_ divided by commas.

--- a/docs/content-typedef.md
+++ b/docs/content-typedef.md
@@ -76,6 +76,8 @@ Function call with fields:
 
 There is no content item representing the result of a function call. Instead, the `ChatMessage` with the role `tool` is used for that purpose. The tool result is then represented as `Content`.
 
+You should not mix function-items with content-items such as text, image etc in one message.
+
 
 ## `ContentItemCtl`
 

--- a/docs/content-typedef.md
+++ b/docs/content-typedef.md
@@ -86,7 +86,10 @@ Inform an LLM about a tool (also called a "function") it can use. See the OpenAI
 
 For `toolspecs_key`, the tool specification is read from the given key.
 
-You should not mix toolspec items with content items like text or images. Instead, provide all `toolspec` items first, followed by all content items.
+You should not mix toolspec items with messages. Instead:
+
+- provide all `toolspec` items first,
+- then continue with messages.
 
 
 ## `ContentItemFunction`

--- a/docs/content-typedef.md
+++ b/docs/content-typedef.md
@@ -75,18 +75,18 @@ Affect the processing of the following items. Currently, its main use is to anno
 See also [OpenAI chat completion messages](https://platform.openai.com/docs/api-reference/chat/create).
 
 
-## `ContentItemToolSpecs`
+## `ContentItemToolSpec`
 
-Create a `tools` section to inform the LLM about what it can use. See the OpenAI documentation on [function calling](https://platform.openai.com/docs/guides/function-calling) for details.
+Inform an LLM about a tool (also called a "function") it can use. See the OpenAI documentation on [function calling](https://platform.openai.com/docs/guides/function-calling) for more details. In particular, the detailed type `ToolSpec` is explained there.
 
-- `[0].type: "toolspecs"`
+- `[0].type: "toolspec"`
 - Either of, but not both:
-  - `[1].toolspecs: FunctionSpec[]`, or
+  - `[1].toolspecs: ToolSpec[]`, or
   - `[1].toolspecs_key: str`
 
-For `toolspecs`, the value is an array of function specifications in the OpenAI format.
+For `toolspecs_key`, the tool specification is read from the given key.
 
-For `toolspecs_key`, the function specifications are read from the given key. The format is extended JSONL: instead of being wrapped in an array, the objects are immediately on the top level and _not_ divided by commas.
+You should not mix toolspec items with content items like text or images. Instead, provide all `toolspec` items first, followed by all content items.
 
 
 ## `ContentItemFunction`

--- a/docs/content-typedef.md
+++ b/docs/content-typedef.md
@@ -65,20 +65,6 @@ When serializing an image blob to markdown:
 - When using a key, copy the blob to a new key with the prefix `out/`. In markdown, reference the `out/` version. Expect that the ailets runner will extract `out/*` blobs for the user.
 
 
-## `ContentItemFunction`
-
-Function call with fields:
-
-- `[0].type: "function"`
-- `[0].id: str` - Function call identifier
-- `[0].name: str` - Function name
-- `[1].arguments: str` - Function arguments
-
-There is no content item representing the result of a function call. Instead, the `ChatMessage` with the role `tool` is used for that purpose. The tool result is then represented as `Content`.
-
-You should not mix function-items with content-items such as text, image etc in one message.
-
-
 ## `ContentItemCtl`
 
 Affect the processing of the following items. Currently, its main use is to annotate "who" said the message. Additionally, if we decide to implement OpenAI choices (multiple outputs), the control message could indicate which choice comes next.
@@ -101,3 +87,19 @@ Create a `tools` section to inform the LLM about what it can use. See the OpenAI
 For `toolspecs`, the value is an array of function specifications in the OpenAI format.
 
 For `toolspecs_key`, the function specifications are read from the given key. The format is extended JSONL: instead of being wrapped in an array, the objects are immediately on the top level and _not_ divided by commas.
+
+
+## `ContentItemFunction`
+
+An artifact of the serialization-deserialization process when calling functions for an LLM. See the OpenAI documentation on [function calling](https://platform.openai.com/docs/guides/function-calling) for more details.
+
+- `[0].type: "function"`
+- `[0].id: str` - Function call identifier
+- `[0].name: str` - Function name
+- `[1].arguments: str` - Function arguments
+
+As a user, you should not create `function` items, but instead use `toolspec` items.
+
+There is no content item representing the result of a function call. Instead, the `ChatMessage` with the role `tool` is used for that purpose. The tool result is then represented as `content` items.
+
+You should not mix function-items with content-items such as text, image etc in one message.

--- a/pylib-v1/ailets/atyping.py
+++ b/pylib-v1/ailets/atyping.py
@@ -387,6 +387,16 @@ class ContentItemFunctionContent(TypedDict):
 ContentItemFunction = Tuple[ContentItemFunctionAttrs, ContentItemFunctionContent]
 
 
+class ContentItemToolSpecAttrs(TypedDict):
+    type: Literal["toolspec"]
+
+class ContentItemToolSpecContent(TypedDict):
+    toolspec: NotRequired[Any]
+    toolspec_key: NotRequired[str]
+
+ContentItemToolSpec = Tuple[ContentItemToolSpecAttrs, ContentItemToolSpecContent]
+
+
 class ContentItemCtlAttrs(TypedDict):
     type: Literal["ctl"]
 
@@ -401,5 +411,6 @@ ContentItem = Union[
     ContentItemImage,
     ContentItemRefusal,
     ContentItemFunction,
+    ContentItemToolSpec,
     ContentItemCtl,
 ]

--- a/pylib-v1/ailets/cons/flow_builder.py
+++ b/pylib-v1/ailets/cons/flow_builder.py
@@ -101,7 +101,9 @@ async def prompt_to_dagops(
             return
 
         if prompt_item.type == "tool":
-            assert prompt_item.tool_name is not None, "Tool name is required for tool type"
+            assert (
+                prompt_item.tool_name is not None
+            ), "Tool name is required for tool type"
             toolspec_item: ContentItemToolSpec = (
                 {
                     "type": "toolspec",

--- a/pylib-v1/ailets/cons/flow_builder.py
+++ b/pylib-v1/ailets/cons/flow_builder.py
@@ -157,7 +157,10 @@ async def prompt_to_dagops(
     last_role = None
     for prompt_item in annotated_prompt:
         role = prompt_item.role
-        if role != last_role:
+        if prompt_item.prompt_item.type == "tool":
+            role = None
+            last_role = None
+        if role != last_role and role is not None:
             role_to_messages(role)
             last_role = role
         await prompt_to_node(prompt_item.prompt_item)

--- a/pylib-v1/ailets/cons/flow_builder.py
+++ b/pylib-v1/ailets/cons/flow_builder.py
@@ -212,7 +212,7 @@ def toolspecs_to_dagops(
             json.dumps(schema).encode("utf-8"),
             env.piper,
             env.processes,
-            explain=f"Tool spec {tool}",
+            explain=f"toolspec {tool}",
         )
 
         prompt.append(
@@ -220,6 +220,15 @@ def toolspecs_to_dagops(
         )
 
     return prompt
+
+
+def toolspecs_to_alias(env: IEnvironment, tools: Sequence[CmdlinePromptItem]) -> str:
+    alias = env.dagops.get_next_name("toolspecs")
+    for tool in tools:
+        env.dagops.alias(alias, tool.value)
+    else:
+        env.dagops.alias(alias, None)
+    return alias
 
 
 def instantiate_with_deps(

--- a/pylib-v1/ailets/cons/flow_builder.py
+++ b/pylib-v1/ailets/cons/flow_builder.py
@@ -156,7 +156,7 @@ async def prompt_to_dagops(
     annotated_prompt = annotate_prompt(prompt)
     last_role = None
     for prompt_item in annotated_prompt:
-        role = prompt_item.role
+        role: Optional[str] = prompt_item.role
         if prompt_item.prompt_item.type == "tool":
             role = None
             last_role = None

--- a/pylib-v1/ailets/cons/plugin.py
+++ b/pylib-v1/ailets/cons/plugin.py
@@ -148,6 +148,6 @@ def hijack_msg2query(nodereg: NodeRegistry, wasm_registry: IWasmRegistry) -> Non
         nodereg,
         wasm_registry,
         ".gpt.messages_to_query",
-        "process_query",
+        "process_messages",
         "messages_to_query.wasm",
     )

--- a/pylib-v1/ailets/cons/typeguards.py
+++ b/pylib-v1/ailets/cons/typeguards.py
@@ -7,6 +7,7 @@ from ailets.atyping import (
     ContentItemImage,
     ContentItemRefusal,
     ContentItemText,
+    ContentItemToolSpec,
 )
 
 
@@ -77,6 +78,19 @@ def is_content_item_ctl(obj: Any) -> TypeGuard[ContentItemCtl]:
     return isinstance(obj1.get("role"), str)
 
 
+def is_content_item_toolspec(obj: Any) -> TypeGuard[ContentItemToolSpec]:
+    if not isinstance(obj, list):
+        return False
+    if len(obj) != 2:
+        return False
+    (obj0, obj1) = obj
+    if not isinstance(obj0, dict) or not isinstance(obj1, dict):
+        return False
+    if obj0.get("type") != "toolspec":
+        return False
+    return "toolspec_key" in obj1 or "toolspec" in obj1
+
+
 def is_content_item(obj: Any) -> TypeGuard[ContentItem]:
     return (
         is_content_item_text(obj)
@@ -84,4 +98,5 @@ def is_content_item(obj: Any) -> TypeGuard[ContentItem]:
         or is_content_item_image(obj)
         or is_content_item_function(obj)
         or is_content_item_ctl(obj)
+        or is_content_item_toolspec(obj)
     )

--- a/pylib-v1/ailets/cons/util.py
+++ b/pylib-v1/ailets/cons/util.py
@@ -10,7 +10,7 @@ from ailets.atyping import IKVBuffers, INodeRuntime, StdHandles
 def get_path(node_name: str, slot_name: Optional[str]) -> str:
     if not slot_name:
         return node_name
-    if "/" in slot_name:
+    if "/" in slot_name or not node_name:
         return slot_name
     return f"{node_name}-{slot_name}"
 

--- a/pylib-v1/ailets/io/input_reader.py
+++ b/pylib-v1/ailets/io/input_reader.py
@@ -65,12 +65,19 @@ class MergeInputReader(IAsyncReader):
         self.index += 1
 
         # Open an attachment from the kv
-        if not len(pipes) and self.index == 0 and "/" in self.slot_name:
-            try:
-                pipe = self.piper.get_existing_pipe("/", self.slot_name)
-                pipes = [pipe]
-            except KeyError:
-                pass
+        if not len(pipes) and self.index == 0:
+            if "/" in self.slot_name:
+                kv_base = "/"
+            elif self.slot_name.startswith("value."):
+                kv_base = ""
+            else:
+                kv_base = None
+            if kv_base is not None:
+                try:
+                    pipe = self.piper.get_existing_pipe(kv_base, self.slot_name)
+                    pipes = [pipe]
+                except KeyError:
+                    pass
 
         if self.index >= len(pipes):
             self.closed = True

--- a/pylib-v1/ailets/models/gpt/__init__.py
+++ b/pylib-v1/ailets/models/gpt/__init__.py
@@ -4,7 +4,6 @@ messages_to_query = NodeDesc(
     name="messages_to_query",
     inputs=[
         Dependency(source=".chat_messages"),
-        Dependency(name="toolspecs", source=".toolspecs"),
     ],
 )
 

--- a/pylib-v1/ailets/models/gpt/__init__.py
+++ b/pylib-v1/ailets/models/gpt/__init__.py
@@ -4,6 +4,7 @@ messages_to_query = NodeDesc(
     name="messages_to_query",
     inputs=[
         Dependency(source=".chat_messages"),
+        Dependency(name="media", source=".chat_messages.media"),
         Dependency(name="toolspecs", source=".chat_messages.toolspecs"),
     ],
 )

--- a/pylib-v1/ailets/models/gpt/__init__.py
+++ b/pylib-v1/ailets/models/gpt/__init__.py
@@ -4,6 +4,7 @@ messages_to_query = NodeDesc(
     name="messages_to_query",
     inputs=[
         Dependency(source=".chat_messages"),
+        Dependency(name="toolspecs", source=".chat_messages.toolspecs"),
     ],
 )
 


### PR DESCRIPTION
- Define `toolspec` and `toolspec_key` for the messages
- New state machine to the structure builder, with `want_*` and `end_*`
- Handling logic of `toolspec` is similar to one of content item
- Show toolspecs in the deps tree again, also show media
- When opening `value.N`, open it from the kv

part of #174 