### PR TITLE
A174 repair response-to-messages for llm functions

### DIFF
--- a/ailets-rs/gpt/src/dagops.rs
+++ b/ailets-rs/gpt/src/dagops.rs
@@ -46,7 +46,14 @@ pub fn inject_tool_calls(
     }
 
     //
-    // Don't interfere with previous model workflow
+    // Don't interfere with previous model workflow:
+    //
+    // - We are going to update the chat history, by adding more to the alias ".chat_messages"
+    // - The old finished run of "user prompt to messages" depended on ".chat_messages"
+    // - If we don't detach, the dependency graph will show that the old "user prompt to messages"
+    //   run depends on the new items in ".chat_messages". It's very very confusing,
+    //   even despite the current runner implementation ignores the dependency changes
+    //   of a finished step.
     //
     dagops.detach_from_alias(".chat_messages")?;
 

--- a/ailets-rs/gpt/src/dagops.rs
+++ b/ailets-rs/gpt/src/dagops.rs
@@ -138,7 +138,7 @@ pub fn inject_tool_calls(
         ])
         .into_iter(),
     )?;
-    dagops.alias(".model_output", rerun_handle)?;
+    dagops.alias(".output_messages", rerun_handle)?;
 
     Ok(())
 }

--- a/ailets-rs/gpt/src/dagops.rs
+++ b/ailets-rs/gpt/src/dagops.rs
@@ -125,7 +125,14 @@ pub fn inject_tool_calls(
     }
 
     // Rerun model
-    let rerun_handle = dagops.instantiate_with_deps(".gpt", HashMap::new().into_iter())?;
+    let rerun_handle = dagops.instantiate_with_deps(
+        ".gpt",
+        HashMap::from([
+            (".chat_messages.media".to_string(), 0),
+            (".chat_messages.toolspecs".to_string(), 0),
+        ])
+        .into_iter(),
+    )?;
     dagops.alias(".model_output", rerun_handle)?;
 
     Ok(())

--- a/ailets-rs/gpt/src/funcalls.rs
+++ b/ailets-rs/gpt/src/funcalls.rs
@@ -94,7 +94,7 @@ impl FunCalls {
     /// - Ensures there's enough space in the vector for the given index
     /// - Merges any existing `current_funcall` data with the vector entry at the specified index
     /// - Sets the streaming mode index
-    /// - Initializes `current_funcall` with a default `ContentItemFunction` if it wasn't already set
+    /// - Initializes `current_funcall` with the existing data at the specified index
     ///
     /// # Arguments
     /// * `index` - The index to set for the current delta position
@@ -121,9 +121,15 @@ impl FunCalls {
         // Set the streaming mode index
         self.idx = Some(index);
 
-        // Initialize current_funcall for streaming mode if it wasn't set
+        // Initialize current_funcall with the existing data at the specified index
         if self.current_funcall.is_none() {
-            self.current_funcall = Some(ContentItemFunction::default());
+            if let Some(existing_funcall) = self.tool_calls.get(index) {
+                self.current_funcall = Some(ContentItemFunction {
+                    id: existing_funcall.id.clone(),
+                    function_name: existing_funcall.function_name.clone(),
+                    function_arguments: existing_funcall.function_arguments.clone(),
+                });
+            }
         }
     }
 

--- a/ailets-rs/gpt/src/funcalls.rs
+++ b/ailets-rs/gpt/src/funcalls.rs
@@ -118,12 +118,9 @@ impl FunCalls {
     /// # Arguments
     /// * `id` - String to append to the current function call's ID
     ///
-    /// # Errors
-    /// Returns an error if the current index is invalid
-    pub fn delta_id(&mut self, id: &str) -> Result<(), String> {
+    pub fn delta_id(&mut self, id: &str) {
         let cell = self.ensure_current();
         cell.id.push_str(id);
-        Ok(())
     }
 
     /// Appends to the function name of the current function call
@@ -131,12 +128,9 @@ impl FunCalls {
     /// # Arguments
     /// * `function_name` - String to append to the current function call's name
     ///
-    /// # Errors
-    /// Returns an error if the current index is invalid
-    pub fn delta_function_name(&mut self, function_name: &str) -> Result<(), String> {
+    pub fn delta_function_name(&mut self, function_name: &str) {
         let cell = self.ensure_current();
         cell.function_name.push_str(function_name);
-        Ok(())
     }
 
     /// Appends to the function arguments of the current function call
@@ -144,12 +138,9 @@ impl FunCalls {
     /// # Arguments
     /// * `function_arguments` - String to append to the current function call's arguments
     ///
-    /// # Errors
-    /// Returns an error if the current index is invalid
-    pub fn delta_function_arguments(&mut self, function_arguments: &str) -> Result<(), String> {
+    pub fn delta_function_arguments(&mut self, function_arguments: &str) {
         let cell = self.ensure_current();
         cell.function_arguments.push_str(function_arguments);
-        Ok(())
     }
 
     /// Returns a reference to the vector of function calls

--- a/ailets-rs/gpt/src/funcalls.rs
+++ b/ailets-rs/gpt/src/funcalls.rs
@@ -62,40 +62,21 @@ impl FunCalls {
         }
     }
 
-    /// Initiates a new round of delta updates by resetting the index
-    pub fn start_delta_round(&mut self) {
-        self.idx = None;
-    }
-
-    /// Starts a new delta update by incrementing the index and ensuring space
-    /// for the new function call
-    pub fn start_delta(&mut self) {
-        self.idx = Some(match self.idx {
-            None => 0,
-            Some(idx) => idx + 1,
-        });
-        if let Some(idx) = self.idx {
-            if idx >= self.tool_calls.len() {
-                self.tool_calls.push(ContentItemFunction::default());
-            }
-        }
-    }
-
-    /// Verifies that the provided index matches the current delta position
+    /// Sets the current delta index and ensures space for the function call
     ///
     /// # Arguments
-    /// * `index` - Expected current position in the collection
+    /// * `index` - The index to set for the current delta position
     ///
     /// # Errors
-    /// Returns an error if the provided index doesn't match the current position
+    /// Returns an error if the index is invalid
     pub fn delta_index(&mut self, index: usize) -> Result<(), String> {
-        if self.idx.unwrap_or(usize::MAX) == index {
-            return Ok(());
+        if self.idx != Some(index) {
+            self.idx = Some(index);
         }
-        Err(format!(
-            "Delta index mismatch. Got: {}, expected: {:?}",
-            index, self.idx
-        ))
+        while self.tool_calls.len() <= index {
+            self.tool_calls.push(ContentItemFunction::default());
+        }
+        Ok(())
     }
 
     /// Appends to the ID of the current function call

--- a/ailets-rs/gpt/src/handlers.rs
+++ b/ailets-rs/gpt/src/handlers.rs
@@ -141,7 +141,10 @@ pub fn on_function_index<W: Write>(
             }
         }
     };
-    builder_cell.borrow_mut().get_funcalls_mut().delta_index(idx);
+    builder_cell
+        .borrow_mut()
+        .get_funcalls_mut()
+        .delta_index(idx);
     StreamOp::ValueIsConsumed
 }
 

--- a/ailets-rs/gpt/src/handlers.rs
+++ b/ailets-rs/gpt/src/handlers.rs
@@ -148,6 +148,15 @@ pub fn on_function_index<W: Write>(
     StreamOp::ValueIsConsumed
 }
 
+/// # Errors
+/// Should never happen.
+pub fn on_function_end<W: Write>(
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    builder_cell.borrow_mut().get_funcalls_mut().end_current();
+    Ok(())
+}
+
 fn on_function_str_field<W: Write, F>(
     rjiter_cell: &RefCell<RJiter>,
     builder_cell: &RefCell<StructureBuilder<W>>,

--- a/ailets-rs/gpt/src/handlers.rs
+++ b/ailets-rs/gpt/src/handlers.rs
@@ -88,7 +88,7 @@ pub fn on_function_id<W: Write>(
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
     on_function_str_field(rjiter_cell, builder_cell, "id", |funcalls, value| {
-        funcalls.delta_id(value)
+        funcalls.delta_id(value);
     })
 }
 
@@ -97,7 +97,7 @@ pub fn on_function_name<W: Write>(
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
     on_function_str_field(rjiter_cell, builder_cell, "name", |funcalls, value| {
-        funcalls.delta_function_name(value)
+        funcalls.delta_function_name(value);
     })
 }
 
@@ -106,7 +106,7 @@ pub fn on_function_arguments<W: Write>(
     builder_cell: &RefCell<StructureBuilder<W>>,
 ) -> StreamOp {
     on_function_str_field(rjiter_cell, builder_cell, "arguments", |funcalls, value| {
-        funcalls.delta_function_arguments(value)
+        funcalls.delta_function_arguments(value);
     })
 }
 
@@ -141,14 +141,7 @@ pub fn on_function_index<W: Write>(
             }
         }
     };
-    if let Err(e) = builder_cell
-        .borrow_mut()
-        .get_funcalls_mut()
-        .delta_index(idx)
-    {
-        let error: Box<dyn std::error::Error> = e.into();
-        return StreamOp::Error(error);
-    }
+    builder_cell.borrow_mut().get_funcalls_mut().delta_index(idx);
     StreamOp::ValueIsConsumed
 }
 
@@ -159,7 +152,7 @@ fn on_function_str_field<W: Write, F>(
     apply_field: F,
 ) -> StreamOp
 where
-    F: FnOnce(&mut crate::funcalls::FunCalls, &str) -> Result<(), String>,
+    F: FnOnce(&mut crate::funcalls::FunCalls, &str),
 {
     let mut rjiter = rjiter_cell.borrow_mut();
     let value = match rjiter.next_str() {
@@ -170,9 +163,6 @@ where
             return StreamOp::Error(error);
         }
     };
-    if let Err(e) = apply_field(builder_cell.borrow_mut().get_funcalls_mut(), value) {
-        let error: Box<dyn std::error::Error> = e.into();
-        return StreamOp::Error(error);
-    }
+    apply_field(builder_cell.borrow_mut().get_funcalls_mut(), value);
     StreamOp::ValueIsConsumed
 }

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -7,8 +7,8 @@ use actor_io::{AReader, AWriter};
 use actor_runtime::{err_to_heap_c_string, extract_errno, DagOps, StdHandle};
 use dagops::{InjectDagOps, InjectDagOpsTrait};
 use handlers::{
-    on_begin_message, on_content, on_end_message, on_function_arguments, on_function_id,
-    on_function_index, on_function_name, on_role,
+    on_begin_message, on_content, on_end_message, on_function_arguments, on_function_end,
+    on_function_id, on_function_index, on_function_name, on_role,
 };
 use scan_json::RJiter;
 use scan_json::{scan, BoxedAction, BoxedEndAction, ContextFrame, Name, ParentAndName, Trigger};
@@ -143,8 +143,12 @@ pub fn _process_gpt<W: Write>(
         Box::new(Name::new("message".to_string())),
         Box::new(on_end_message) as BoxedEndAction<StructureBuilder<W>>,
     );
+    let end_tool_calls = Trigger::new(
+        Box::new(Name::new("tool_calls".to_string())),
+        Box::new(on_function_end) as BoxedEndAction<StructureBuilder<W>>,
+    );
     let triggers = make_triggers::<W>();
-    let triggers_end = vec![end_message];
+    let triggers_end = vec![end_message, end_tool_calls];
     let sse_tokens = vec![String::from("data:"), String::from("DONE")];
 
     scan(

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -11,7 +11,10 @@ use handlers::{
     on_function_id, on_function_index, on_function_name, on_role,
 };
 use scan_json::RJiter;
-use scan_json::{scan, BoxedAction, BoxedEndAction, ContextFrame, Name, ParentAndName, Trigger};
+use scan_json::{
+    scan, BoxedAction, BoxedEndAction, ContextFrame, Name, ParentAndName, ParentParentAndName,
+    Trigger,
+};
 use std::cell::RefCell;
 use std::ffi::c_char;
 use std::io::Write;
@@ -143,12 +146,16 @@ pub fn _process_gpt<W: Write>(
         Box::new(Name::new("message".to_string())),
         Box::new(on_end_message) as BoxedEndAction<StructureBuilder<W>>,
     );
-    let end_tool_calls = Trigger::new(
-        Box::new(Name::new("tool_calls".to_string())),
+    let end_tool_call = Trigger::new(
+        Box::new(ParentParentAndName::new(
+            "tool_calls".to_string(),
+            "#array".to_string(),
+            "#object".to_string(),
+        )),
         Box::new(on_function_end) as BoxedEndAction<StructureBuilder<W>>,
     );
     let triggers = make_triggers::<W>();
-    let triggers_end = vec![end_message, end_tool_calls];
+    let triggers_end = vec![end_message, end_tool_call];
     let sse_tokens = vec![String::from("data:"), String::from("DONE")];
 
     scan(

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -7,8 +7,8 @@ use actor_io::{AReader, AWriter};
 use actor_runtime::{err_to_heap_c_string, extract_errno, DagOps, StdHandle};
 use dagops::{InjectDagOps, InjectDagOpsTrait};
 use handlers::{
-    on_begin_message, on_choices, on_content, on_end_message, on_function_arguments,
-    on_function_begin, on_function_id, on_function_index, on_function_name, on_role,
+    on_begin_message, on_content, on_end_message, on_function_arguments, on_function_id,
+    on_function_index, on_function_name, on_role,
 };
 use scan_json::RJiter;
 use scan_json::{scan, BoxedAction, BoxedEndAction, ContextFrame, Name, ParentAndName, Trigger};
@@ -58,13 +58,7 @@ fn make_triggers<'a, W: Write + 'a>() -> Vec<Trigger<'a, BA<'a, W>>> {
         Box::new(Name::new("message".to_string())),
         Box::new(on_begin_message) as BA<'a, W>,
     );
-    let choices = Trigger::new(
-        Box::new(ParentAndName::new(
-            "#top".to_string(),
-            "choices".to_string(),
-        )),
-        Box::new(on_choices) as BA<'a, W>,
-    );
+
     let message_role = Trigger::new(
         Box::new(ParentAndName::new(
             "message".to_string(),
@@ -91,12 +85,6 @@ fn make_triggers<'a, W: Write + 'a>() -> Vec<Trigger<'a, BA<'a, W>>> {
         Box::new(on_content) as BA<'a, W>,
     );
 
-    let function_begin = Trigger::new(
-        Box::new(MatchInToolCall {
-            field: "#object".to_string(),
-        }),
-        Box::new(on_function_begin) as BA<'a, W>,
-    );
     let function_id = Trigger::new(
         Box::new(MatchInToolCall {
             field: "id".to_string(),
@@ -124,12 +112,10 @@ fn make_triggers<'a, W: Write + 'a>() -> Vec<Trigger<'a, BA<'a, W>>> {
 
     let triggers = vec![
         begin_message,
-        choices,
         message_role,
         message_content,
         delta_role,
         delta_content,
-        function_begin,
         function_id,
         function_name,
         function_arguments,

--- a/ailets-rs/gpt/tests/actor_test.rs
+++ b/ailets-rs/gpt/tests/actor_test.rs
@@ -54,6 +54,7 @@ fn funcall_response() {
         )]
     );
 }
+
 #[test]
 fn funcall_streaming() {
     let fixture_content = std::fs::read_to_string("tests/fixture/funcall_streaming.txt")
@@ -72,5 +73,25 @@ fn funcall_streaming() {
             "get_user_name",
             "{}"
         )]
+    );
+}
+
+#[test]
+fn delta_index_regress() {
+    let fixture_content = std::fs::read_to_string("tests/fixture/delta_index_regress.txt")
+        .expect("Failed to read fixture file 'delta_index_regress.txt'");
+    let reader = Cursor::new(fixture_content);
+    let writer = RcWriter::new();
+    let mut dagops = TrackedInjectDagOps::new();
+
+    _process_gpt(reader, writer.clone(), &mut dagops).unwrap();
+
+    assert_eq!(writer.get_output(), "");
+    assert_eq!(
+        dagops.get_tool_calls(),
+        &[
+            ContentItemFunction::new("call_O8vJyvRJrH6ST1ssD97c3jPI", "get_user_name", "{}"),
+            ContentItemFunction::new("call_5fx8xXsKGpAhCNDTZsYoWWUx", "get_user_name", "{}")
+        ]
     );
 }

--- a/ailets-rs/gpt/tests/dagops_test.rs
+++ b/ailets-rs/gpt/tests/dagops_test.rs
@@ -243,7 +243,7 @@ fn inject_tool_calls_to_dag() {
     assert_that!(alias_handle, is(equal_to(handle_aftercall_2)));
 
     let (_, alias_name, alias_handle) = tracked_dagops.parse_alias(&tracked_dagops.aliases[3]);
-    assert_that!(&alias_name, is(equal_to(".model_output")));
+    assert_that!(&alias_name, is(equal_to(".output_messages")));
     assert_that!(alias_handle, is(equal_to(handle_rerun)));
 }
 

--- a/ailets-rs/gpt/tests/dagops_test.rs
+++ b/ailets-rs/gpt/tests/dagops_test.rs
@@ -44,25 +44,21 @@ fn inject_tool_calls_to_dag() {
     );
 
     let expected_tcch = json!([
-        {
-            "role": "assistant",
-            "tool_calls": [
-                [{
-                    "type": "function",
-                    "id": "call_1",
-                    "name": "get_weather",
-                  },{
-                    "arguments": "{\"city\":\"London\"}"
-                }],
-                [{
-                    "type": "function",
-                    "id": "call_2",
-                    "name": "get_forecast",
-                  },{
-                    "arguments": "{\"days\":5}"
-                }]
-            ]
-        }
+        [{"type":"ctl"},{"role":"assistant"}],
+        [{
+            "type": "function",
+            "id": "call_1",
+            "name": "get_weather",
+          },{
+            "arguments": "{\"city\":\"London\"}"
+        }],
+        [{
+            "type": "function",
+            "id": "call_2",
+            "name": "get_forecast",
+          },{
+            "arguments": "{\"days\":5}"
+        }]
     ]);
     let value_tcch =
         serde_json::from_str(&value_tcch).expect(&format!("Failed to parse JSON: {value_tcch}"));

--- a/ailets-rs/gpt/tests/dagops_test.rs
+++ b/ailets-rs/gpt/tests/dagops_test.rs
@@ -211,7 +211,13 @@ fn inject_tool_calls_to_dag() {
     //
     let (handle_rerun, rerun_workflow, deps_rerun) = tracked_dagops.parse_workflow(&workflows[4]);
     assert_that!(rerun_workflow, is(equal_to(format!(".gpt"))));
-    assert_that!(deps_rerun, is(equal_to(HashMap::from([]))));
+    assert_that!(
+        deps_rerun,
+        is(equal_to(HashMap::from([
+            (".chat_messages.media".to_string(), 0),
+            (".chat_messages.toolspecs".to_string(), 0),
+        ])))
+    );
 
     //
     // Assert: aliases

--- a/ailets-rs/gpt/tests/dagops_test.rs
+++ b/ailets-rs/gpt/tests/dagops_test.rs
@@ -60,9 +60,16 @@ fn inject_tool_calls_to_dag() {
             "arguments": "{\"days\":5}"
         }]
     ]);
-    let value_tcch =
-        serde_json::from_str(&value_tcch).expect(&format!("Failed to parse JSON: {value_tcch}"));
-    assert_that!(value_tcch, is(equal_to(expected_tcch)));
+    let value_tcch_lines: Vec<serde_json::Value> = value_tcch
+        .lines()
+        .map(|line| {
+            serde_json::from_str(line).expect(&format!("Failed to parse JSON line: {line}"))
+        })
+        .collect();
+    assert_that!(
+        serde_json::Value::Array(value_tcch_lines),
+        is(equal_to(expected_tcch))
+    );
 
     //
     // Assert: `get_weather` tool input and call spec

--- a/ailets-rs/gpt/tests/fixture/delta_index_regress.txt
+++ b/ailets-rs/gpt/tests/fixture/delta_index_regress.txt
@@ -1,0 +1,13 @@
+data: {"id":"chatcmpl-Bq9kRfg3yCXn8NvI3NOvp4UU94WPa","object":"chat.completion.chunk","created":1751770227,"model":"gpt-4.1-nano-2025-04-14","service_tier":"default","system_fingerprint":"fp_38343a2f8f","choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-Bq9kRfg3yCXn8NvI3NOvp4UU94WPa","object":"chat.completion.chunk","created":1751770227,"model":"gpt-4.1-nano-2025-04-14","service_tier":"default","system_fingerprint":"fp_38343a2f8f","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_O8vJyvRJrH6ST1ssD97c3jPI","type":"function","function":{"name":"get_user_name","arguments":""}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-Bq9kRfg3yCXn8NvI3NOvp4UU94WPa","object":"chat.completion.chunk","created":1751770227,"model":"gpt-4.1-nano-2025-04-14","service_tier":"default","system_fingerprint":"fp_38343a2f8f","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-Bq9kRfg3yCXn8NvI3NOvp4UU94WPa","object":"chat.completion.chunk","created":1751770227,"model":"gpt-4.1-nano-2025-04-14","service_tier":"default","system_fingerprint":"fp_38343a2f8f","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"id":"call_5fx8xXsKGpAhCNDTZsYoWWUx","type":"function","function":{"name":"get_user_name","arguments":""}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-Bq9kRfg3yCXn8NvI3NOvp4UU94WPa","object":"chat.completion.chunk","created":1751770227,"model":"gpt-4.1-nano-2025-04-14","service_tier":"default","system_fingerprint":"fp_38343a2f8f","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{}"}}]},"logprobs":null,"finish_reason":null}]}
+
+data: {"id":"chatcmpl-Bq9kRfg3yCXn8NvI3NOvp4UU94WPa","object":"chat.completion.chunk","created":1751770227,"model":"gpt-4.1-nano-2025-04-14","service_tier":"default","system_fingerprint":"fp_38343a2f8f","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}]}
+
+data: [DONE]

--- a/ailets-rs/gpt/tests/funcalls_test.rs
+++ b/ailets-rs/gpt/tests/funcalls_test.rs
@@ -5,10 +5,11 @@ fn single_funcall() {
     let mut funcalls = FunCalls::new();
 
     // Act
-    funcalls.delta_index(0).unwrap();
-    funcalls.delta_id("call_9cFpsOXfVWMUoDz1yyyP1QXD").unwrap();
-    funcalls.delta_function_name("get_user_name").unwrap();
-    funcalls.delta_function_arguments("{}").unwrap();
+    funcalls.delta_index(0);
+    funcalls.delta_id("call_9cFpsOXfVWMUoDz1yyyP1QXD");
+    funcalls.delta_function_name("get_user_name");
+    funcalls.delta_function_arguments("{}");
+    funcalls.end_current();
 
     // Assert
     let tool_calls = funcalls.get_tool_calls();
@@ -22,128 +23,6 @@ fn single_funcall() {
     );
 }
 
-#[test]
-fn check_index() {
-    // Arrange
-    let mut funcalls = FunCalls::new();
-
-    // Act
-    assert!(funcalls.delta_index(0).is_ok());
-    assert!(funcalls.delta_index(1).is_ok()); // Now we can set any index
-}
-
-#[test]
-fn delta_appends() {
-    // Arrange
-    let mut funcalls = FunCalls::new();
-
-    // Act
-    funcalls.delta_index(0).unwrap();
-    funcalls.delta_id("call_1").unwrap();
-    funcalls.delta_function_name("func1").unwrap();
-    funcalls.delta_function_arguments("{}").unwrap();
-
-    funcalls.delta_id("call_2").unwrap();
-    funcalls.delta_function_name("func2").unwrap();
-    funcalls.delta_function_arguments("{\"param\":2}").unwrap();
-
-    // Assert
-    let tool_calls = funcalls.get_tool_calls();
-    assert_eq!(
-        tool_calls,
-        &vec![ContentItemFunction::new(
-            "call_1call_2",
-            "func1func2",
-            "{}{\"param\":2}"
-        )]
-    );
-}
-
-#[test]
-fn several_rounds_with_delta() {
-    let mut funcalls = FunCalls::new();
-
-    // Act: first round
-    funcalls.delta_index(0).unwrap();
-    funcalls.delta_id("call_1").unwrap();
-    funcalls.delta_function_name("func1").unwrap();
-    funcalls.delta_function_arguments("{}").unwrap();
-    funcalls.delta_index(1).unwrap();
-    funcalls.delta_id("call_2").unwrap();
-    funcalls.delta_function_name("func2").unwrap();
-    funcalls.delta_function_arguments("{\"param\":2}").unwrap();
-
-    // Act: second round - append to existing items
-    funcalls.delta_index(0).unwrap();
-    funcalls.delta_id("++").unwrap();
-    funcalls.delta_function_name("++").unwrap();
-    funcalls.delta_function_arguments("++").unwrap();
-    funcalls.delta_index(1).unwrap();
-    funcalls.delta_id("==").unwrap();
-    funcalls.delta_function_name("==").unwrap();
-    funcalls.delta_function_arguments("==").unwrap();
-
-    // Assert
-    let tool_calls = funcalls.get_tool_calls();
-    assert_eq!(
-        tool_calls,
-        &vec![
-            ContentItemFunction::new("call_1++", "func1++", "{}++"),
-            ContentItemFunction::new("call_2==", "func2==", "{\"param\":2}=="),
-        ]
-    );
-}
-
-#[test]
-fn start_delta_reuse() {
-    let mut funcalls = FunCalls::new();
-
-    // Act: create 3 items
-    funcalls.delta_index(0).unwrap();
-    funcalls.delta_index(1).unwrap();
-    funcalls.delta_index(2).unwrap();
-
-    // Assert: 3 items are created
-    let tool_calls = funcalls.get_tool_calls();
-    assert_eq!(
-        tool_calls,
-        &vec![
-            ContentItemFunction::default(),
-            ContentItemFunction::default(),
-            ContentItemFunction::default(),
-        ]
-    );
-
-    // Act: create a new item
-    funcalls.delta_index(3).unwrap();
-
-    // Assert: now there are 4 items
-    let tool_calls = funcalls.get_tool_calls();
-    assert_eq!(
-        tool_calls,
-        &vec![
-            ContentItemFunction::default(),
-            ContentItemFunction::default(),
-            ContentItemFunction::default(),
-            ContentItemFunction::default(),
-        ]
-    );
-}
-
-#[test]
-fn has_cell_for_delta() {
-    let mut funcalls = FunCalls::new();
-    let expected_err = "No active delta index";
-
-    let result = funcalls.delta_id("foo");
-    assert_eq!(result.unwrap_err(), expected_err);
-
-    let result = funcalls.delta_function_name("foo");
-    assert_eq!(result.unwrap_err(), expected_err);
-
-    let result = funcalls.delta_function_arguments("foo");
-    assert_eq!(result.unwrap_err(), expected_err);
-}
 
 #[test]
 fn delta_index_regress_scenario() {
@@ -151,16 +30,18 @@ fn delta_index_regress_scenario() {
 
     // Simulate the delta_index_regress.txt scenario:
     // First tool call with index 0
-    funcalls.delta_index(0).unwrap();
-    funcalls.delta_id("call_O8vJyvRJrH6ST1ssD97c3jPI").unwrap();
-    funcalls.delta_function_name("get_user_name").unwrap();
-    funcalls.delta_function_arguments("{}").unwrap();
+    funcalls.delta_index(0);
+    funcalls.delta_id("call_O8vJyvRJrH6ST1ssD97c3jPI");
+    funcalls.delta_function_name("get_user_name");
+    funcalls.delta_function_arguments("{}");
+    funcalls.end_current();
 
     // Second tool call with index 1
-    funcalls.delta_index(1).unwrap();
-    funcalls.delta_id("call_5fx8xXsKGpAhCNDTZsYoWWUx").unwrap();
-    funcalls.delta_function_name("get_user_name").unwrap();
-    funcalls.delta_function_arguments("{}").unwrap();
+    funcalls.delta_index(1);
+    funcalls.delta_id("call_5fx8xXsKGpAhCNDTZsYoWWUx");
+    funcalls.delta_function_name("get_user_name");
+    funcalls.delta_function_arguments("{}");
+    funcalls.end_current();
 
     // Assert
     let tool_calls = funcalls.get_tool_calls();

--- a/ailets-rs/gpt/tests/funcalls_test.rs
+++ b/ailets-rs/gpt/tests/funcalls_test.rs
@@ -55,3 +55,143 @@ fn several_funcalls_direct() {
         ]
     );
 }
+
+#[test]
+fn single_element_streaming_one_round() {
+    let mut funcalls = FunCalls::new();
+
+    // Act - streaming mode with delta_index
+    funcalls.delta_index(0);
+    funcalls.delta_id("call_9cFpsOXfVWMUoDz1yyyP1QXD");
+    funcalls.delta_function_name("get_user_name");
+    funcalls.delta_function_arguments("{}");
+    funcalls.end_current();
+
+    // Assert
+    let tool_calls = funcalls.get_tool_calls();
+    assert_eq!(
+        tool_calls,
+        &vec![ContentItemFunction::new(
+            "call_9cFpsOXfVWMUoDz1yyyP1QXD",
+            "get_user_name",
+            "{}",
+        )]
+    );
+}
+
+#[test]
+fn single_element_streaming_several_rounds() {
+    let mut funcalls = FunCalls::new();
+
+    // Act - streaming mode with delta_index, multiple rounds
+    // Round 1: Start building the element
+    funcalls.delta_index(0);
+    funcalls.delta_id("call_9cFps");
+    funcalls.delta_function_name("get_user");
+    funcalls.end_current();
+
+    // Round 2: Continue building the same element (accumulate)
+    funcalls.delta_id("call_9cFpsOXfVWMUoDz1yyyP1QXD");
+    funcalls.delta_function_name("get_user_name");
+    funcalls.delta_index(0);
+    funcalls.delta_function_arguments("{}");
+    funcalls.end_current();
+
+    // Assert
+    let tool_calls = funcalls.get_tool_calls();
+    assert_eq!(
+        tool_calls,
+        &vec![ContentItemFunction::new(
+            "call_9cFpscall_9cFpsOXfVWMUoDz1yyyP1QXD",
+            "get_userget_user_name",
+            "{}",
+        )]
+    );
+}
+
+#[test]
+fn several_elements_streaming_one_round() {
+    let mut funcalls = FunCalls::new();
+
+    // Act - streaming mode with delta_index, multiple elements in one round
+    funcalls.delta_index(0);
+    funcalls.delta_id("call_foo");
+    funcalls.delta_function_name("get_foo");
+    funcalls.delta_function_arguments("{foo_args}");
+    funcalls.end_current();
+
+    funcalls.delta_id("call_bar");
+    funcalls.delta_function_name("get_bar");
+    funcalls.delta_function_arguments("{bar_args}");
+    funcalls.delta_index(1);
+    funcalls.end_current();
+
+    funcalls.delta_index(2);
+    funcalls.delta_id("call_baz");
+    funcalls.delta_function_name("get_baz");
+    funcalls.delta_function_arguments("{baz_args}");
+    funcalls.end_current();
+
+    // Assert
+    let tool_calls = funcalls.get_tool_calls();
+    assert_eq!(
+        tool_calls,
+        &vec![
+            ContentItemFunction::new("call_foo", "get_foo", "{foo_args}"),
+            ContentItemFunction::new("call_bar", "get_bar", "{bar_args}"),
+            ContentItemFunction::new("call_baz", "get_baz", "{baz_args}"),
+        ]
+    );
+}
+
+#[test]
+fn several_elements_streaming_several_rounds() {
+    let mut funcalls = FunCalls::new();
+
+    // Act - streaming mode with delta_index, multiple elements and multiple rounds
+    // Round 1: Start building all elements
+    funcalls.delta_index(0);
+    funcalls.delta_id("call_foo");
+    funcalls.delta_function_name("get_foo");
+    funcalls.end_current();
+
+    funcalls.delta_id("call_bar");
+    funcalls.delta_index(1);
+    funcalls.delta_function_name("get_bar");
+    funcalls.end_current();
+
+    funcalls.delta_id("call_baz");
+    funcalls.delta_function_name("get_baz");
+    funcalls.delta_index(2);
+    funcalls.end_current();
+
+    // Round 2: Add more to all elements (should accumulate)
+    funcalls.delta_id("_extra");
+    funcalls.delta_function_name("_plus");
+    funcalls.delta_function_arguments("{foo_args}");
+    funcalls.delta_index(0);
+    funcalls.end_current();
+
+    funcalls.delta_id("_extra");
+    funcalls.delta_index(1);
+    funcalls.delta_function_name("_plus");
+    funcalls.delta_function_arguments("{bar_args}");
+    funcalls.end_current();
+
+    funcalls.delta_index(2);
+    funcalls.delta_id("_extra");
+    funcalls.delta_function_name("_plus");
+    funcalls.delta_function_arguments("{baz_args}");
+    funcalls.end_current();
+
+    // Assert
+    let tool_calls = funcalls.get_tool_calls();
+    assert_eq!(
+        tool_calls,
+        &vec![
+            ContentItemFunction::new("call_foo_extra", "get_foo_plus", "{foo_args}"),
+            ContentItemFunction::new("call_bar_extra", "get_bar_plus", "{bar_args}"),
+            ContentItemFunction::new("call_baz_extra", "get_baz_plus", "{baz_args}"),
+        ]
+    );
+}

--- a/ailets-rs/gpt/tests/funcalls_test.rs
+++ b/ailets-rs/gpt/tests/funcalls_test.rs
@@ -1,11 +1,10 @@
 use gpt::funcalls::{ContentItemFunction, FunCalls};
 
 #[test]
-fn single_funcall() {
+fn single_funcall_direct() {
     let mut funcalls = FunCalls::new();
 
     // Act
-    funcalls.delta_index(0);
     funcalls.delta_id("call_9cFpsOXfVWMUoDz1yyyP1QXD");
     funcalls.delta_function_name("get_user_name");
     funcalls.delta_function_arguments("{}");
@@ -23,24 +22,26 @@ fn single_funcall() {
     );
 }
 
-
 #[test]
-fn delta_index_regress_scenario() {
+fn several_funcalls_direct() {
     let mut funcalls = FunCalls::new();
 
-    // Simulate the delta_index_regress.txt scenario:
     // First tool call with index 0
-    funcalls.delta_index(0);
-    funcalls.delta_id("call_O8vJyvRJrH6ST1ssD97c3jPI");
-    funcalls.delta_function_name("get_user_name");
-    funcalls.delta_function_arguments("{}");
+    funcalls.delta_id("call_foo");
+    funcalls.delta_function_name("get_foo");
+    funcalls.delta_function_arguments("{foo_args}");
     funcalls.end_current();
 
     // Second tool call with index 1
-    funcalls.delta_index(1);
-    funcalls.delta_id("call_5fx8xXsKGpAhCNDTZsYoWWUx");
-    funcalls.delta_function_name("get_user_name");
-    funcalls.delta_function_arguments("{}");
+    funcalls.delta_id("call_bar");
+    funcalls.delta_function_name("get_bar");
+    funcalls.delta_function_arguments("{bar_args}");
+    funcalls.end_current();
+
+    // Third tool call with index 2
+    funcalls.delta_id("call_baz");
+    funcalls.delta_function_name("get_baz");
+    funcalls.delta_function_arguments("{baz_args}");
     funcalls.end_current();
 
     // Assert
@@ -48,8 +49,9 @@ fn delta_index_regress_scenario() {
     assert_eq!(
         tool_calls,
         &vec![
-            ContentItemFunction::new("call_O8vJyvRJrH6ST1ssD97c3jPI", "get_user_name", "{}"),
-            ContentItemFunction::new("call_5fx8xXsKGpAhCNDTZsYoWWUx", "get_user_name", "{}")
+            ContentItemFunction::new("call_foo", "get_foo", "{foo_args}"),
+            ContentItemFunction::new("call_bar", "get_bar", "{bar_args}"),
+            ContentItemFunction::new("call_baz", "get_baz", "{baz_args}"),
         ]
     );
 }

--- a/ailets-rs/gpt/tests/handlers_test.rs
+++ b/ailets-rs/gpt/tests/handlers_test.rs
@@ -67,8 +67,9 @@ fn on_function_string_field() {
     assert!(matches!(result, StreamOp::ValueIsConsumed));
 
     // Assert: Verify that the function name was set in FunCalls
-    let builder = builder_cell.borrow();
-    let funcalls = builder.get_funcalls();
+    let mut builder = builder_cell.borrow_mut();
+    let funcalls = builder.get_funcalls_mut();
+    funcalls.end_current();
     assert_eq!(
         funcalls.get_tool_calls(),
         &[ContentItemFunction::new("", "test_function", "")]
@@ -93,42 +94,6 @@ fn on_function_string_field_invalid_value_type() {
     let result = on_function_name(&rjiter_cell, &builder_cell);
 
     // Assert
-    assert!(matches!(result, StreamOp::Error(_)));
-    let builder = builder_cell.borrow();
-    let funcalls = builder.get_funcalls();
-    assert_eq!(
-        funcalls.get_tool_calls(),
-        &[ContentItemFunction::new("", "", "")]
-    );
-}
-
-#[test]
-fn test_on_function_index() {
-    // Arrange
-    let mut buffer = Cursor::new(Vec::new());
-    let builder = StructureBuilder::new(&mut buffer);
-    let builder_cell = RefCell::new(builder);
-
-    // Arrange: Create RJiter with input for 3 tests
-    let json = "2 2 2";
-    let mut json_reader = Cursor::new(json);
-    let mut buffer = [0u8; 32];
-    let rjiter = RJiter::new(&mut json_reader, &mut buffer);
-    let rjiter_cell = RefCell::new(rjiter);
-
-    // Act and assert: Out of range
-    let result = on_function_index(&rjiter_cell, &builder_cell);
-    assert!(matches!(result, StreamOp::Error(_)));
-
-    // Act and assert: Valid index
-    // on_function_begin(&rjiter_cell, &builder_cell);
-    // on_function_begin(&rjiter_cell, &builder_cell);
-    // on_function_begin(&rjiter_cell, &builder_cell);
-    let result = on_function_index(&rjiter_cell, &builder_cell);
-    assert!(matches!(result, StreamOp::ValueIsConsumed));
-
-    // Act and assert: Index mismatch
-    let result = on_function_index(&rjiter_cell, &builder_cell);
     assert!(matches!(result, StreamOp::Error(_)));
 }
 

--- a/ailets-rs/gpt/tests/handlers_test.rs
+++ b/ailets-rs/gpt/tests/handlers_test.rs
@@ -1,8 +1,6 @@
 use actor_runtime_mocked::RcWriter;
 use gpt::funcalls::ContentItemFunction;
-use gpt::handlers::{
-    on_choices, on_content, on_function_begin, on_function_index, on_function_name,
-};
+use gpt::handlers::{on_content, on_function_index, on_function_name};
 use gpt::structure_builder::StructureBuilder;
 use scan_json::{RJiter, StreamOp};
 use std::cell::RefCell;
@@ -65,7 +63,6 @@ fn on_function_string_field() {
     let rjiter_cell = RefCell::new(rjiter);
 
     // Act
-    on_function_begin(&rjiter_cell, &builder_cell);
     let result = on_function_name(&rjiter_cell, &builder_cell);
     assert!(matches!(result, StreamOp::ValueIsConsumed));
 
@@ -93,7 +90,6 @@ fn on_function_string_field_invalid_value_type() {
     let rjiter_cell = RefCell::new(rjiter);
 
     // Act
-    on_function_begin(&rjiter_cell, &builder_cell);
     let result = on_function_name(&rjiter_cell, &builder_cell);
 
     // Assert
@@ -125,15 +121,13 @@ fn test_on_function_index() {
     assert!(matches!(result, StreamOp::Error(_)));
 
     // Act and assert: Valid index
-    on_function_begin(&rjiter_cell, &builder_cell);
-    on_function_begin(&rjiter_cell, &builder_cell);
-    on_function_begin(&rjiter_cell, &builder_cell);
+    // on_function_begin(&rjiter_cell, &builder_cell);
+    // on_function_begin(&rjiter_cell, &builder_cell);
+    // on_function_begin(&rjiter_cell, &builder_cell);
     let result = on_function_index(&rjiter_cell, &builder_cell);
     assert!(matches!(result, StreamOp::ValueIsConsumed));
 
     // Act and assert: Index mismatch
-    on_choices(&rjiter_cell, &builder_cell);
-    on_function_begin(&rjiter_cell, &builder_cell);
     let result = on_function_index(&rjiter_cell, &builder_cell);
     assert!(matches!(result, StreamOp::Error(_)));
 }

--- a/ailets-rs/messages_to_query/src/handlers.rs
+++ b/ailets-rs/messages_to_query/src/handlers.rs
@@ -297,13 +297,32 @@ pub fn on_toolspec_key<W: Write>(
         Ok(k) => k,
         Err(e) => {
             return StreamOp::Error(
-                format!("Error getting toolspec_key value. Expected string, got: {e:?}").into(),
+                format!("Error getting toolspec key value. Expected string, got: {e:?}").into(),
             );
         }
     };
+    if let Err(e) = builder_cell.borrow_mut().toolspec_key(key) {
+        return StreamOp::Error(e.into());
+    }
+    StreamOp::ValueIsConsumed
+}
 
+pub fn on_tool_call_id<W: Write>(
+    rjiter_cell: &RefCell<RJiter>,
+    builder_cell: &RefCell<StructureBuilder<W>>,
+) -> StreamOp {
+    let mut rjiter = rjiter_cell.borrow_mut();
+    let value = match rjiter.next_str() {
+        Ok(v) => v,
+        Err(e) => {
+            return StreamOp::Error(
+                format!("Error getting attribute 'tool_call_id'. Expected string, got: {e:?}")
+                    .into(),
+            );
+        }
+    };
     let mut builder = builder_cell.borrow_mut();
-    if let Err(e) = builder.toolspec_key(key) {
+    if let Err(e) = builder.add_item_attribute(String::from("tool_call_id"), String::from(value)) {
         return StreamOp::Error(e.into());
     }
     StreamOp::ValueIsConsumed

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -95,6 +95,13 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         )),
         Box::new(handlers::on_toolspec_key) as BoxedAction<'_, StructureBuilder<W>>,
     );
+    let tool_call_id = Trigger::new(
+        Box::new(ParentAndName::new(
+            "#array".to_string(),
+            "tool_call_id".to_string(),
+        )),
+        Box::new(handlers::on_tool_call_id) as BoxedAction<'_, StructureBuilder<W>>,
+    );
 
     vec![
         item_type,
@@ -109,6 +116,7 @@ fn create_begin_triggers<'a, W: Write + 'a>(
         func_arguments,
         toolspec,
         toolspec_key,
+        tool_call_id,
         role,
     ]
 }

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -275,3 +275,24 @@ fn toolspec_by_key() {
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
+
+#[test]
+fn tool_role_with_tool_call_id() {
+    let input = r#"[{"type": "ctl", "tool_call_id": "call_hEUJSGdhP42m1HYos3OTEeCS"}, {"role": "tool"}]
+                   [{"type": "text"}, {"text": "{}"}]
+                   [{"type": "text"}, {"text": "{\"get_user_name\": \"olpa\"}"}]"#;
+    let reader = Cursor::new(input);
+    let writer = RcWriter::new();
+
+    _process_messages(reader, writer.clone(), create_empty_env_opts()).unwrap();
+    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+        .expect("Failed to parse output as JSON");
+
+    let expected_item = r#"[{"role":"tool","tool_call_id":"call_hEUJSGdhP42m1HYos3OTEeCS","content":[
+        {"type":"text","text":"{}"},
+        {"type":"text","text":"{\"get_user_name\": \"olpa\"}"}
+    ]}]"#;
+    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+        .expect("Failed to parse expected output as JSON");
+    assert_that!(output_json, equal_to(expected_json));
+}

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -345,19 +345,11 @@ async def main() -> None:
         env = Environment(nodereg, kv=vfs)
         toml_to_env(env, model_opts, args.opt, toml=prompt)
         tools_prompt = toolspecs_to_dagops(env, args.tools)
-        tools_alias = toolspecs_to_alias(env, tools_prompt)
+        toolspecs_to_alias(env, tools_prompt)
         media_ref_prompt = media_to_dagops(env, prompt)
-        media_alias = media_to_alias(env, media_ref_prompt)
+        media_to_alias(env, media_ref_prompt)
         await prompt_to_dagops(env, prompt=list(tools_prompt) + list(media_ref_prompt))
-        model_node_name = instantiate_with_deps(
-            env.dagops,
-            nodereg,
-            f".{model}",
-            {
-                ".chat_messages.toolspecs": tools_alias,
-                ".chat_messages.media": media_alias,
-            },
-        )
+        model_node_name = instantiate_with_deps(env.dagops, nodereg, f".{model}", {})
         env.dagops.alias(".model_output", model_node_name)
 
         target_node_name = instantiate_with_deps(

--- a/command-line-tool/ailets0.py
+++ b/command-line-tool/ailets0.py
@@ -350,7 +350,7 @@ async def main() -> None:
         media_to_alias(env, media_ref_prompt)
         await prompt_to_dagops(env, prompt=list(tools_prompt) + list(media_ref_prompt))
         model_node_name = instantiate_with_deps(env.dagops, nodereg, f".{model}", {})
-        env.dagops.alias(".model_output", model_node_name)
+        env.dagops.alias(".output_messages", model_node_name)
 
         target_node_name = instantiate_with_deps(
             env.dagops, nodereg, ".messages_to_markdown", {}

--- a/docs/content-typedef.md
+++ b/docs/content-typedef.md
@@ -70,7 +70,10 @@ When serializing an image blob to markdown:
 Affect the processing of the following items. Currently, its main use is to annotate "who" said the message. Additionally, if we decide to implement OpenAI choices (multiple outputs), the control message could indicate which choice comes next.
 
 - `[0].type: "ctl"`
+- `[0].tool_call_id: Optional[str]`
 - `[1].role: "system"|"user"|"assistant"|"tool"|str`
+
+If the role is `tool`, then the attribute `tool_call_id` is required, otherwise if the role is not `tool`, the attribute is not used.
 
 See also [OpenAI chat completion messages](https://platform.openai.com/docs/api-reference/chat/create).
 

--- a/pylib-v1/ailets/actor_runtime/node_dagops.py
+++ b/pylib-v1/ailets/actor_runtime/node_dagops.py
@@ -17,7 +17,7 @@ class NodeDagops(INodeDagops):
         self.piper = env.piper
         self.processes = env.processes
         self.node = node
-        self.handle_to_name: List[str] = []
+        self.handle_to_name: List[str] = ['no-node-id-0']
 
     def add_value_node(self, value: bytes, explain: Optional[str] = None) -> str:
         node = self.dagops.add_value_node(value, self.piper, self.processes, explain)
@@ -55,9 +55,16 @@ class NodeDagops(INodeDagops):
 
         return len(self.handle_to_name) - 1
 
+    def _resolve_alias_handle(self, alias: str, handle: int) -> str:
+        """Resolve an alias using dagops if handle is 0, otherwise use handle_to_name."""
+        if handle == 0:
+            return alias
+        else:
+            return self.handle_to_name[handle]
+
     def v2_instantiate_with_deps(self, target: str, aliases: dict[str, int]) -> int:
         name_aliases = {
-            alias: self.handle_to_name[handle] for alias, handle in aliases.items()
+            alias: self._resolve_alias_handle(alias, handle) for alias, handle in aliases.items()
         }
 
         node_name = self.instantiate_with_deps(target, name_aliases)

--- a/pylib-v1/ailets/cons/flow_builder.py
+++ b/pylib-v1/ailets/cons/flow_builder.py
@@ -218,7 +218,7 @@ def media_to_dagops(
 
 def media_to_alias(env: IEnvironment, whole_prompt: Sequence[CmdlinePromptItem]) -> str:
     media = [prompt_item for prompt_item in whole_prompt if prompt_item.type == "file"]
-    alias = env.dagops.get_next_name("media")
+    alias = ".chat_messages.media"
     for media_item in media:
         env.dagops.alias(alias, media_item.node_name)
     else:
@@ -251,7 +251,7 @@ def toolspecs_to_dagops(
 
 
 def toolspecs_to_alias(env: IEnvironment, tools: Sequence[CmdlinePromptItem]) -> str:
-    alias = env.dagops.get_next_name("toolspecs")
+    alias = ".chat_messages.toolspecs"
     for tool in tools:
         env.dagops.alias(alias, tool.node_name)
     else:

--- a/pylib-v1/ailets/stdlib/__init__.py
+++ b/pylib-v1/ailets/stdlib/__init__.py
@@ -19,7 +19,7 @@ query = NodeDesc(
 messages_to_markdown = NodeDesc(
     name="messages_to_markdown",
     inputs=[
-        Dependency(source=".model_output"),
+        Dependency(source=".output_messages"),
     ],
 )
 


### PR DESCRIPTION
- Use the streaming messaging format for tool results
- Rework `FunCalls` logic
- Use aliases `chat_messages.media` and `chat_messages.toolspec`
- Switch to the alias `output_messages` from `model_output`
- Doesn't work for Anthropic, submitted a bug
