### PR TITLE
A258 Regression: Stop waiting for latent writers on shutdown

### DIFF
--- a/ailets-rs/ailetos/src/pipe/pool.rs
+++ b/ailets-rs/ailetos/src/pipe/pool.rs
@@ -183,6 +183,7 @@ impl PipePool {
 
             // Wait for notification if needed, then loop back to recheck
             if let Some(mut rx) = wait_notify {
+                debug!(key = ?key, "reader waiting on latent pipe");
                 // Err means the Sender was dropped; treat as wakeup.
                 let _ = rx.changed().await;
             }

--- a/ailets-rs/cli/src/lib.rs
+++ b/ailets-rs/cli/src/lib.rs
@@ -257,9 +257,11 @@ impl DagShell {
         for &handle in &self.handles {
             self.env.suspension.resume(handle);
         }
-        // Drain reader tasks before dropping the executor: ensures last bytes written
-        // by actors are flushed even in fast-exit scenarios where the runtime would
-        // otherwise drop the tasks before they are scheduled.
+        // Unblock reader tasks waiting on pipes that will never be realized
+        // (e.g. a node whose dep failed without ever opening stdout).
+        // Must happen before draining reader_tasks to avoid deadlock.
+        self.env.pipe_pool.close_all_leftover_writers();
+        tracing::debug!(count = self.reader_tasks.len(), "prepare_exit: draining reader tasks");
         let rt = &self.ailetos_async_rt;
         let tasks = &mut self.reader_tasks;
         rt.block_on(async { while tasks.join_next().await.is_some() {} });

--- a/ailets-rs/cli/src/lib.rs
+++ b/ailets-rs/cli/src/lib.rs
@@ -261,7 +261,10 @@ impl DagShell {
         // (e.g. a node whose dep failed without ever opening stdout).
         // Must happen before draining reader_tasks to avoid deadlock.
         self.env.pipe_pool.close_all_leftover_writers();
-        tracing::debug!(count = self.reader_tasks.len(), "prepare_exit: draining reader tasks");
+        tracing::debug!(
+            count = self.reader_tasks.len(),
+            "prepare_exit: draining reader tasks"
+        );
         let rt = &self.ailetos_async_rt;
         let tasks = &mut self.reader_tasks;
         rt.block_on(async { while tasks.join_next().await.is_some() {} });


### PR DESCRIPTION
Ccall `pipe_pool.close_all_leftover_writers()` explicitly in `prepare_exit` before the drain, so latent-pipe waiters are unblocked in time.