### PR TITLE
A274 optional stream selection in dagsh "cat"

### DIFF
--- a/ailets-rs/actor_runtime/src/lib.rs
+++ b/ailets-rs/actor_runtime/src/lib.rs
@@ -26,6 +26,22 @@ pub enum StdHandle {
     _Count,
 }
 
+impl TryFrom<&str> for StdHandle {
+    type Error = ();
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "stdin" => Ok(StdHandle::Stdin),
+            "stdout" => Ok(StdHandle::Stdout),
+            "stderr" | "log" => Ok(StdHandle::Log),
+            "env" => Ok(StdHandle::Env),
+            "metrics" => Ok(StdHandle::Metrics),
+            "trace" => Ok(StdHandle::Trace),
+            _ => Err(()),
+        }
+    }
+}
+
 /// Convert file descriptor to `StdHandle`, enabling exhaustive match in consumer code.
 /// This ensures compiler errors when new variants are added.
 impl TryFrom<isize> for StdHandle {

--- a/ailets-rs/cat/src/lib.rs
+++ b/ailets-rs/cat/src/lib.rs
@@ -48,7 +48,12 @@ fn execute_impl<'a>(mut reader: AReader<'a>, mut writer: AWriter<'a>) -> Result<
 pub fn execute(runtime: &dyn ActorRuntime) -> Result<(), String> {
     let reader = AReader::new_from_std(runtime, StdHandle::Stdin);
     let writer = AWriter::new_from_std(runtime, StdHandle::Stdout);
-    execute_impl(reader, writer)
+    let result = execute_impl(reader, writer);
+    if let Err(ref e) = result {
+        let mut log = AWriter::new_from_std(runtime, StdHandle::Log);
+        if log.write_all(format!("{e}\n").as_bytes()).is_err() {}
+    }
+    result
 }
 
 /// WASM FFI wrapper

--- a/ailets-rs/cat/src/lib.rs
+++ b/ailets-rs/cat/src/lib.rs
@@ -60,10 +60,7 @@ pub fn execute(runtime: &dyn ActorRuntime) -> Result<(), String> {
 #[no_mangle]
 pub extern "C" fn execute_wasm() -> *const c_char {
     let runtime = FfiActorRuntime::new();
-    let reader = AReader::new_from_std(&runtime, StdHandle::Stdin);
-    let writer = AWriter::new_from_std(&runtime, StdHandle::Stdout);
-
-    match execute_impl(reader, writer) {
+    match execute(&runtime) {
         Ok(()) => std::ptr::null(),
         Err(e) => err_to_heap_c_string(-1, &e),
     }

--- a/ailets-rs/cli/src/commands.rs
+++ b/ailets-rs/cli/src/commands.rs
@@ -177,7 +177,8 @@ impl DagShell {
         let name = name.to_string();
         let mut targets = Vec::new();
         for target_str in targets_strs {
-            let target = self.parse_handle(target_str)
+            let target = self
+                .parse_handle(target_str)
                 .ok_or_else(|| format!("Invalid handle: {target_str}"))?;
             targets.push(target);
         }
@@ -237,10 +238,12 @@ impl DagShell {
             [n, d, ..] => (*n, *d),
             _ => return Err("Usage: dep <node> <dependency>".to_string()),
         };
-        let node =
-            self.parse_handle(node_str).ok_or_else(|| format!("Invalid handle: {node_str}"))?;
-        let dep =
-            self.parse_handle(dep_str).ok_or_else(|| format!("Invalid handle: {dep_str}"))?;
+        let node = self
+            .parse_handle(node_str)
+            .ok_or_else(|| format!("Invalid handle: {node_str}"))?;
+        let dep = self
+            .parse_handle(dep_str)
+            .ok_or_else(|| format!("Invalid handle: {dep_str}"))?;
         self.env
             .dag
             .write()
@@ -298,7 +301,8 @@ impl DagShell {
             return Ok(());
         }
         let handle_str = args.first().ok_or("Usage: show <node>")?;
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         let suspension = Some(&*self.env.suspension);
         let tree = dag.dump_colored(handle, suspension, Some(&pending));
@@ -349,14 +353,18 @@ impl DagShell {
                 &"--stop-before" => {
                     i += 1;
                     let h = args.get(i).ok_or("--stop-before requires a node")?;
-                    stop_before =
-                        Some(self.parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?);
+                    stop_before = Some(
+                        self.parse_handle(h)
+                            .ok_or_else(|| format!("Invalid handle: {h}"))?,
+                    );
                 }
                 &"--stop-after" => {
                     i += 1;
                     let h = args.get(i).ok_or("--stop-after requires a node")?;
-                    stop_after =
-                        Some(self.parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?);
+                    stop_after = Some(
+                        self.parse_handle(h)
+                            .ok_or_else(|| format!("Invalid handle: {h}"))?,
+                    );
                 }
                 arg if !arg.starts_with("--") => {
                     target_arg = Some(arg);
@@ -367,7 +375,8 @@ impl DagShell {
         }
 
         let handle = if let Some(h) = target_arg {
-            self.parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?
+            self.parse_handle(h)
+                .ok_or_else(|| format!("Invalid handle: {h}"))?
         } else if let Some(sb) = stop_before {
             sb
         } else {
@@ -488,7 +497,8 @@ pub static ENTRY_JOIN: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_join(&mut self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: join <node>")?;
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         let handles = self.env.resolve_all(handle);
         self.join_handles(&handles)
@@ -527,7 +537,8 @@ impl DagShell {
         }
 
         let handle_str = handle_str.ok_or("Usage: follow <node> [--color <name>]")?;
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         for target in self.env.resolve_all(handle) {
@@ -641,7 +652,8 @@ impl DagShell {
             _ => return Err("Usage: kill [-N] <node>".to_string()),
         };
 
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         if !dbg_control::is_dbg_node(handle) {
@@ -673,7 +685,7 @@ impl DagShell {
             return Ok(h);
         }
         let fd: isize = s.parse().map_err(|_| format!("Unknown stream: {s}"))?;
-        StdHandle::try_from(fd).map_err(|_| format!("Unknown stream: {s}"))
+        StdHandle::try_from(fd).map_err(|()| format!("Unknown stream: {s}"))
     }
 
     pub(crate) fn cmd_cat(&self, args: &[&str]) -> Result<(), String> {
@@ -702,7 +714,7 @@ impl DagShell {
                         format!("Node {} was never executed", handle.id())
                     }
                     Some(NodeState::Running | NodeState::Terminating) => {
-                        format!("Node {} is still running", handle.id())
+                        format!("Node {} is running but hasn't created stream {stream:?} yet", handle.id())
                     }
                     Some(NodeState::Terminated) | None => {
                         format!("No output on stream {stream:?} for node {}", handle.id())
@@ -886,7 +898,8 @@ pub static ENTRY_SUSPEND: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_suspend(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: suspend <node>")?;
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         self.env.suspension.suspend(handle);
         self.sink
@@ -905,7 +918,8 @@ pub static ENTRY_RESUME: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_resume(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: resume <node>")?;
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         self.env.suspension.resume(handle);
         self.sink.println(&format!("Resumed node {}", handle.id()));
@@ -930,7 +944,8 @@ impl DagShell {
         match *condition {
             "suspended" => {
                 let handle_str = args.get(1).ok_or("Usage: wait suspended <node>")?;
-                let handle = self.parse_handle(handle_str)
+                let handle = self
+                    .parse_handle(handle_str)
                     .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
                 let env = &self.env;
                 let sink = &self.sink;
@@ -953,7 +968,8 @@ impl DagShell {
             }
             "terminated" => {
                 let handle_str = args.get(1).ok_or("Usage: wait terminated <node>")?;
-                let handle = self.parse_handle(handle_str)
+                let handle = self
+                    .parse_handle(handle_str)
                     .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
                 let env = &self.env;
                 let sink = &self.sink;
@@ -996,7 +1012,8 @@ pub static ENTRY_WRITE: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_write(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: write <node> <data>")?;
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         let data = parse_quoted_string(args.get(1..).unwrap_or(&[]));
@@ -1022,7 +1039,8 @@ pub static ENTRY_CLOSE: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_close(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: close <node>")?;
-        let handle = self.parse_handle(handle_str)
+        let handle = self
+            .parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         match shell_input_control::close_shell_input(handle) {

--- a/ailets-rs/cli/src/commands.rs
+++ b/ailets-rs/cli/src/commands.rs
@@ -668,28 +668,25 @@ pub static ENTRY_CAT: CommandMeta = CommandMeta {
     detail: None,
 };
 impl DagShell {
-    fn parse_stream(s: &str) -> Result<isize, String> {
-        match s {
-            "stdin" => Ok(StdHandle::Stdin as isize),
-            "stdout" => Ok(StdHandle::Stdout as isize),
-            "stderr" | "log" => Ok(StdHandle::Log as isize),
-            "env" => Ok(StdHandle::Env as isize),
-            "metrics" => Ok(StdHandle::Metrics as isize),
-            "trace" => Ok(StdHandle::Trace as isize),
-            _ => s
-                .parse::<isize>()
-                .ok()
-                .filter(|&fd| fd >= 0 && fd < StdHandle::_Count as isize)
-                .ok_or_else(|| format!("Unknown stream: {s}")),
+    fn parse_stream(s: &str) -> Result<StdHandle, String> {
+        let handle = if let Ok(h) = StdHandle::try_from(s) {
+            h
+        } else {
+            let fd: isize = s.parse().map_err(|_| format!("Unknown stream: {s}"))?;
+            StdHandle::try_from(fd).map_err(|_| format!("Unknown stream: {s}"))?
+        };
+        if handle == StdHandle::Stdin {
+            return Err("stdin is not a readable output stream".to_string());
         }
+        Ok(handle)
     }
 
     pub(crate) fn cmd_cat(&self, args: &[&str]) -> Result<(), String> {
         let arg = args.first().ok_or("Usage: cat <node>[:<stream>]")?;
-        let (node_str, fd) = if let Some((node_part, stream_part)) = arg.split_once(':') {
+        let (node_str, stream) = if let Some((node_part, stream_part)) = arg.split_once(':') {
             (node_part, Self::parse_stream(stream_part)?)
         } else {
-            (*arg, StdHandle::Stdout as isize)
+            (*arg, StdHandle::Stdout)
         };
         let handle = self
             .parse_handle(node_str)
@@ -697,7 +694,7 @@ impl DagShell {
 
         let kv = Arc::clone(&self.kv);
         let output = self.ailetos_async_rt.block_on(async move {
-            let path = pipe_path(handle, fd);
+            let path = pipe_path(handle, stream as isize);
             match kv.open(&path, OpenMode::Read).await {
                 Ok(buffer) => {
                     let guard = buffer.lock();

--- a/ailets-rs/cli/src/commands.rs
+++ b/ailets-rs/cli/src/commands.rs
@@ -715,7 +715,10 @@ impl DagShell {
                         format!("Node {} was never executed", handle.id())
                     }
                     Some(NodeState::Running | NodeState::Terminating) => {
-                        format!("Node {} is running but hasn't created stream {stream_name} yet", handle.id())
+                        format!(
+                            "Node {} is running but hasn't created stream {stream_name} yet",
+                            handle.id()
+                        )
                     }
                     Some(NodeState::Terminated) | None => {
                         format!("No output on stream {stream_name} for node {}", handle.id())

--- a/ailets-rs/cli/src/commands.rs
+++ b/ailets-rs/cli/src/commands.rs
@@ -680,21 +680,22 @@ pub static ENTRY_CAT: CommandMeta = CommandMeta {
     detail: None,
 };
 impl DagShell {
-    fn parse_stream(s: &str) -> Result<StdHandle, String> {
+    fn parse_stream(s: &str) -> Result<isize, String> {
         if let Ok(h) = StdHandle::try_from(s) {
-            return Ok(h);
+            return Ok(h as isize);
         }
-        let fd: isize = s.parse().map_err(|_| format!("Unknown stream: {s}"))?;
-        StdHandle::try_from(fd).map_err(|()| format!("Unknown stream: {s}"))
+        s.parse().map_err(|_| format!("Unknown stream: {s}"))
     }
 
     pub(crate) fn cmd_cat(&self, args: &[&str]) -> Result<(), String> {
         let arg = args.first().ok_or("Usage: cat <node>[:<stream>]")?;
-        let (node_str, stream) = if let Some((node_part, stream_part)) = arg.split_once(':') {
+        let (node_str, stream_fd) = if let Some((node_part, stream_part)) = arg.split_once(':') {
             (node_part, Self::parse_stream(stream_part)?)
         } else {
-            (*arg, StdHandle::Stdout)
+            (*arg, StdHandle::Stdout as isize)
         };
+        let stream_name = StdHandle::try_from(stream_fd)
+            .map_or_else(|()| format!("fd={stream_fd}"), |h| format!("{h:?}"));
         let handle = self
             .parse_handle(node_str)
             .ok_or_else(|| format!("Invalid handle: {node_str}"))?;
@@ -703,7 +704,7 @@ impl DagShell {
 
         let kv = Arc::clone(&self.kv);
         let output = self.ailetos_async_rt.block_on(async move {
-            let path = pipe_path(handle, stream as isize);
+            let path = pipe_path(handle, stream_fd);
             match kv.open(&path, OpenMode::Read).await {
                 Ok(buffer) => {
                     let guard = buffer.lock();
@@ -714,10 +715,10 @@ impl DagShell {
                         format!("Node {} was never executed", handle.id())
                     }
                     Some(NodeState::Running | NodeState::Terminating) => {
-                        format!("Node {} is running but hasn't created stream {stream:?} yet", handle.id())
+                        format!("Node {} is running but hasn't created stream {stream_name} yet", handle.id())
                     }
                     Some(NodeState::Terminated) | None => {
-                        format!("No output on stream {stream:?} for node {}", handle.id())
+                        format!("No output on stream {stream_name} for node {}", handle.id())
                     }
                 }),
             }

--- a/ailets-rs/cli/src/commands.rs
+++ b/ailets-rs/cli/src/commands.rs
@@ -662,20 +662,42 @@ impl DagShell {
 
 pub static ENTRY_CAT: CommandMeta = CommandMeta {
     names: &["cat"],
-    argsig: "node",
+    argsig: "node[:stream]",
     section: "I/O",
-    description: "Show output of a node",
+    description: "Show output of a node (default stream: stdout)",
     detail: None,
 };
 impl DagShell {
+    fn parse_stream(s: &str) -> Result<isize, String> {
+        match s {
+            "stdin" => Ok(StdHandle::Stdin as isize),
+            "stdout" => Ok(StdHandle::Stdout as isize),
+            "stderr" | "log" => Ok(StdHandle::Log as isize),
+            "env" => Ok(StdHandle::Env as isize),
+            "metrics" => Ok(StdHandle::Metrics as isize),
+            "trace" => Ok(StdHandle::Trace as isize),
+            _ => s
+                .parse::<isize>()
+                .ok()
+                .filter(|&fd| fd >= 0 && fd < StdHandle::_Count as isize)
+                .ok_or_else(|| format!("Unknown stream: {s}")),
+        }
+    }
+
     pub(crate) fn cmd_cat(&self, args: &[&str]) -> Result<(), String> {
-        let handle_str = args.first().ok_or("Usage: cat <node>")?;
-        let handle = self.parse_handle(handle_str)
-            .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
+        let arg = args.first().ok_or("Usage: cat <node>[:<stream>]")?;
+        let (node_str, fd) = if let Some((node_part, stream_part)) = arg.split_once(':') {
+            (node_part, Self::parse_stream(stream_part)?)
+        } else {
+            (*arg, StdHandle::Stdout as isize)
+        };
+        let handle = self
+            .parse_handle(node_str)
+            .ok_or_else(|| format!("Invalid handle: {node_str}"))?;
 
         let kv = Arc::clone(&self.kv);
         let output = self.ailetos_async_rt.block_on(async move {
-            let path = pipe_path(handle, StdHandle::Stdout as isize);
+            let path = pipe_path(handle, fd);
             match kv.open(&path, OpenMode::Read).await {
                 Ok(buffer) => {
                     let guard = buffer.lock();

--- a/ailets-rs/cli/src/commands.rs
+++ b/ailets-rs/cli/src/commands.rs
@@ -177,7 +177,7 @@ impl DagShell {
         let name = name.to_string();
         let mut targets = Vec::new();
         for target_str in targets_strs {
-            let target = Self::parse_handle(target_str)
+            let target = self.parse_handle(target_str)
                 .ok_or_else(|| format!("Invalid handle: {target_str}"))?;
             targets.push(target);
         }
@@ -238,9 +238,9 @@ impl DagShell {
             _ => return Err("Usage: dep <node> <dependency>".to_string()),
         };
         let node =
-            Self::parse_handle(node_str).ok_or_else(|| format!("Invalid handle: {node_str}"))?;
+            self.parse_handle(node_str).ok_or_else(|| format!("Invalid handle: {node_str}"))?;
         let dep =
-            Self::parse_handle(dep_str).ok_or_else(|| format!("Invalid handle: {dep_str}"))?;
+            self.parse_handle(dep_str).ok_or_else(|| format!("Invalid handle: {dep_str}"))?;
         self.env
             .dag
             .write()
@@ -298,7 +298,7 @@ impl DagShell {
             return Ok(());
         }
         let handle_str = args.first().ok_or("Usage: show <node>")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         let suspension = Some(&*self.env.suspension);
         let tree = dag.dump_colored(handle, suspension, Some(&pending));
@@ -350,13 +350,13 @@ impl DagShell {
                     i += 1;
                     let h = args.get(i).ok_or("--stop-before requires a node")?;
                     stop_before =
-                        Some(Self::parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?);
+                        Some(self.parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?);
                 }
                 &"--stop-after" => {
                     i += 1;
                     let h = args.get(i).ok_or("--stop-after requires a node")?;
                     stop_after =
-                        Some(Self::parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?);
+                        Some(self.parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?);
                 }
                 arg if !arg.starts_with("--") => {
                     target_arg = Some(arg);
@@ -367,7 +367,7 @@ impl DagShell {
         }
 
         let handle = if let Some(h) = target_arg {
-            Self::parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?
+            self.parse_handle(h).ok_or_else(|| format!("Invalid handle: {h}"))?
         } else if let Some(sb) = stop_before {
             sb
         } else {
@@ -488,7 +488,7 @@ pub static ENTRY_JOIN: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_join(&mut self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: join <node>")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         let handles = self.env.resolve_all(handle);
         self.join_handles(&handles)
@@ -527,7 +527,7 @@ impl DagShell {
         }
 
         let handle_str = handle_str.ok_or("Usage: follow <node> [--color <name>]")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         for target in self.env.resolve_all(handle) {
@@ -641,7 +641,7 @@ impl DagShell {
             _ => return Err("Usage: kill [-N] <node>".to_string()),
         };
 
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         if !dbg_control::is_dbg_node(handle) {
@@ -670,7 +670,7 @@ pub static ENTRY_CAT: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_cat(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: cat <node>")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         let kv = Arc::clone(&self.kv);
@@ -715,7 +715,7 @@ impl DagShell {
         let [handle_str, ..] = args else {
             return;
         };
-        let Some(handle) = Self::parse_handle(handle_str) else {
+        let Some(handle) = self.parse_handle(handle_str) else {
             self.sink.println(&format!("Invalid handle: {handle_str}"));
             return;
         };
@@ -863,7 +863,7 @@ pub static ENTRY_SUSPEND: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_suspend(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: suspend <node>")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         self.env.suspension.suspend(handle);
         self.sink
@@ -882,7 +882,7 @@ pub static ENTRY_RESUME: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_resume(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: resume <node>")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
         self.env.suspension.resume(handle);
         self.sink.println(&format!("Resumed node {}", handle.id()));
@@ -907,7 +907,7 @@ impl DagShell {
         match *condition {
             "suspended" => {
                 let handle_str = args.get(1).ok_or("Usage: wait suspended <node>")?;
-                let handle = Self::parse_handle(handle_str)
+                let handle = self.parse_handle(handle_str)
                     .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
                 let env = &self.env;
                 let sink = &self.sink;
@@ -930,7 +930,7 @@ impl DagShell {
             }
             "terminated" => {
                 let handle_str = args.get(1).ok_or("Usage: wait terminated <node>")?;
-                let handle = Self::parse_handle(handle_str)
+                let handle = self.parse_handle(handle_str)
                     .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
                 let env = &self.env;
                 let sink = &self.sink;
@@ -973,7 +973,7 @@ pub static ENTRY_WRITE: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_write(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: write <node> <data>")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         let data = parse_quoted_string(args.get(1..).unwrap_or(&[]));
@@ -999,7 +999,7 @@ pub static ENTRY_CLOSE: CommandMeta = CommandMeta {
 impl DagShell {
     pub(crate) fn cmd_close(&self, args: &[&str]) -> Result<(), String> {
         let handle_str = args.first().ok_or("Usage: close <node>")?;
-        let handle = Self::parse_handle(handle_str)
+        let handle = self.parse_handle(handle_str)
             .ok_or_else(|| format!("Invalid handle: {handle_str}"))?;
 
         match shell_input_control::close_shell_input(handle) {

--- a/ailets-rs/cli/src/commands.rs
+++ b/ailets-rs/cli/src/commands.rs
@@ -669,16 +669,11 @@ pub static ENTRY_CAT: CommandMeta = CommandMeta {
 };
 impl DagShell {
     fn parse_stream(s: &str) -> Result<StdHandle, String> {
-        let handle = if let Ok(h) = StdHandle::try_from(s) {
-            h
-        } else {
-            let fd: isize = s.parse().map_err(|_| format!("Unknown stream: {s}"))?;
-            StdHandle::try_from(fd).map_err(|_| format!("Unknown stream: {s}"))?
-        };
-        if handle == StdHandle::Stdin {
-            return Err("stdin is not a readable output stream".to_string());
+        if let Ok(h) = StdHandle::try_from(s) {
+            return Ok(h);
         }
-        Ok(handle)
+        let fd: isize = s.parse().map_err(|_| format!("Unknown stream: {s}"))?;
+        StdHandle::try_from(fd).map_err(|_| format!("Unknown stream: {s}"))
     }
 
     pub(crate) fn cmd_cat(&self, args: &[&str]) -> Result<(), String> {
@@ -692,6 +687,8 @@ impl DagShell {
             .parse_handle(node_str)
             .ok_or_else(|| format!("Invalid handle: {node_str}"))?;
 
+        let node_state = self.env.dag.read().get_node(handle).map(|n| n.state);
+
         let kv = Arc::clone(&self.kv);
         let output = self.ailetos_async_rt.block_on(async move {
             let path = pipe_path(handle, stream as isize);
@@ -700,10 +697,17 @@ impl DagShell {
                     let guard = buffer.lock();
                     Ok(String::from_utf8_lossy(&guard).into_owned())
                 }
-                Err(e) => Err(format!(
-                    "No output available for node {}: {e:?}",
-                    handle.id()
-                )),
+                Err(_) => Err(match node_state {
+                    Some(NodeState::NotStarted) => {
+                        format!("Node {} was never executed", handle.id())
+                    }
+                    Some(NodeState::Running | NodeState::Terminating) => {
+                        format!("Node {} is still running", handle.id())
+                    }
+                    Some(NodeState::Terminated) | None => {
+                        format!("No output on stream {stream:?} for node {}", handle.id())
+                    }
+                }),
             }
         });
         match output {

--- a/ailets-rs/cli/src/lib.rs
+++ b/ailets-rs/cli/src/lib.rs
@@ -215,8 +215,22 @@ impl DagShell {
         }
     }
 
-    pub(crate) fn parse_handle(s: &str) -> Option<Handle> {
-        s.parse::<i64>().ok().map(Handle::new)
+    pub(crate) fn parse_handle(&self, s: &str) -> Option<Handle> {
+        if let Ok(id) = s.parse::<i64>() {
+            return Some(Handle::new(id));
+        }
+        let dag = self.env.dag.read();
+        if let Some((name, n_str)) = s.rsplit_once('.') {
+            let id: i64 = n_str.parse().ok()?;
+            let handle = Handle::new(id);
+            dag.get_node(handle)
+                .filter(|n| n.idname == name)
+                .map(|_| handle)
+        } else {
+            let mut matches = dag.nodes().filter(|n| n.idname == s);
+            let first = matches.next()?;
+            matches.next().is_none().then(|| first.pid)
+        }
     }
 
     /// Evaluate a TCL script.  Variables set in one call are visible in subsequent calls

--- a/ailets-rs/cli/src/lib.rs
+++ b/ailets-rs/cli/src/lib.rs
@@ -229,7 +229,7 @@ impl DagShell {
         } else {
             let mut matches = dag.nodes().filter(|n| n.idname == s);
             let first = matches.next()?;
-            matches.next().is_none().then(|| first.pid)
+            matches.next().is_none().then_some(first.pid)
         }
     }
 

--- a/ailets-rs/cli/tests/shell.rs
+++ b/ailets-rs/cli/tests/shell.rs
@@ -467,15 +467,16 @@ fn parse_handle_name_dot_n() {
     let mut shell = DagShell::new_with_sink(Box::new(sink.clone()));
     let (mut interp, ctx) = make_interp();
     // node cat gets id 1; cat.1 must resolve, wrong.1 must not
-    shell.execute(&mut interp, ctx, "set id [node cat]").unwrap();
     shell
-        .execute(&mut interp, ctx, "status cat.$id")
+        .execute(&mut interp, ctx, "set id [node cat]")
         .unwrap();
+    shell.execute(&mut interp, ctx, "status cat.$id").unwrap();
     assert!(sink.lines().iter().any(|l| l.contains("cat")));
-    shell
-        .execute(&mut interp, ctx, "status wrong.$id")
-        .unwrap();
-    assert!(sink.lines().iter().any(|l| l.contains("Invalid handle: wrong.")));
+    shell.execute(&mut interp, ctx, "status wrong.$id").unwrap();
+    assert!(sink
+        .lines()
+        .iter()
+        .any(|l| l.contains("Invalid handle: wrong.")));
 }
 
 #[test]
@@ -489,7 +490,10 @@ fn parse_handle_unique_name() {
     assert!(sink.lines().iter().any(|l| l.contains("cat")));
     shell.execute(&mut interp, ctx, "node cat").unwrap();
     shell.execute(&mut interp, ctx, "status cat").unwrap();
-    assert!(sink.lines().iter().any(|l| l.contains("Invalid handle: cat")));
+    assert!(sink
+        .lines()
+        .iter()
+        .any(|l| l.contains("Invalid handle: cat")));
 }
 
 #[test]
@@ -497,9 +501,17 @@ fn cat_stream_by_name_and_fd() {
     let sink = CapturingSink::new();
     let mut shell = DagShell::new_with_sink(Box::new(sink.clone()));
     let (mut interp, ctx) = make_interp();
-    shell.execute(&mut interp, ctx, "set v [value hello]").unwrap();
+    shell
+        .execute(&mut interp, ctx, "set v [value hello]")
+        .unwrap();
     shell.execute(&mut interp, ctx, "cat $v:stderr").unwrap();
     shell.execute(&mut interp, ctx, "cat $v:2").unwrap();
     let lines = sink.lines();
-    assert_eq!(lines.iter().filter(|l| l.contains("No output on stream")).count(), 2);
+    assert_eq!(
+        lines
+            .iter()
+            .filter(|l| l.contains("No output on stream"))
+            .count(),
+        2
+    );
 }

--- a/ailets-rs/cli/tests/shell.rs
+++ b/ailets-rs/cli/tests/shell.rs
@@ -491,3 +491,15 @@ fn parse_handle_unique_name() {
     shell.execute(&mut interp, ctx, "status cat").unwrap();
     assert!(sink.lines().iter().any(|l| l.contains("Invalid handle: cat")));
 }
+
+#[test]
+fn cat_stream_by_name_and_fd() {
+    let sink = CapturingSink::new();
+    let mut shell = DagShell::new_with_sink(Box::new(sink.clone()));
+    let (mut interp, ctx) = make_interp();
+    shell.execute(&mut interp, ctx, "set v [value hello]").unwrap();
+    shell.execute(&mut interp, ctx, "cat $v:stderr").unwrap();
+    shell.execute(&mut interp, ctx, "cat $v:2").unwrap();
+    let lines = sink.lines();
+    assert_eq!(lines.iter().filter(|l| l.contains("No output available")).count(), 2);
+}

--- a/ailets-rs/cli/tests/shell.rs
+++ b/ailets-rs/cli/tests/shell.rs
@@ -460,3 +460,34 @@ fn tcl_multiline_value_sets_node() {
         "expected node status output; got: {lines:?}"
     );
 }
+
+#[test]
+fn parse_handle_name_dot_n() {
+    let sink = CapturingSink::new();
+    let mut shell = DagShell::new_with_sink(Box::new(sink.clone()));
+    let (mut interp, ctx) = make_interp();
+    // node cat gets id 1; cat.1 must resolve, wrong.1 must not
+    shell.execute(&mut interp, ctx, "set id [node cat]").unwrap();
+    shell
+        .execute(&mut interp, ctx, "status cat.$id")
+        .unwrap();
+    assert!(sink.lines().iter().any(|l| l.contains("cat")));
+    shell
+        .execute(&mut interp, ctx, "status wrong.$id")
+        .unwrap();
+    assert!(sink.lines().iter().any(|l| l.contains("Invalid handle: wrong.")));
+}
+
+#[test]
+fn parse_handle_unique_name() {
+    let sink = CapturingSink::new();
+    let mut shell = DagShell::new_with_sink(Box::new(sink.clone()));
+    let (mut interp, ctx) = make_interp();
+    // single cat resolves; adding a second makes it ambiguous
+    shell.execute(&mut interp, ctx, "node cat").unwrap();
+    shell.execute(&mut interp, ctx, "status cat").unwrap();
+    assert!(sink.lines().iter().any(|l| l.contains("cat")));
+    shell.execute(&mut interp, ctx, "node cat").unwrap();
+    shell.execute(&mut interp, ctx, "status cat").unwrap();
+    assert!(sink.lines().iter().any(|l| l.contains("Invalid handle: cat")));
+}

--- a/ailets-rs/cli/tests/shell.rs
+++ b/ailets-rs/cli/tests/shell.rs
@@ -501,5 +501,5 @@ fn cat_stream_by_name_and_fd() {
     shell.execute(&mut interp, ctx, "cat $v:stderr").unwrap();
     shell.execute(&mut interp, ctx, "cat $v:2").unwrap();
     let lines = sink.lines();
-    assert_eq!(lines.iter().filter(|l| l.contains("No output available")).count(), 2);
+    assert_eq!(lines.iter().filter(|l| l.contains("No output on stream")).count(), 2);
 }

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -8,9 +8,9 @@ pub mod handlers;
 pub mod structure_builder;
 
 use actor_io::{AReader, AWriter};
-use embedded_io::Write as _;
 use actor_runtime::{err_to_heap_c_string, ActorRuntime, FfiActorRuntime, StdHandle};
 use dagops::{DagOps, DagOpsTrait, StubDagOps};
+use embedded_io::Write as _;
 
 use handlers::{
     on_begin_message, on_content, on_end_message, on_function_arguments, on_function_end,

--- a/ailets-rs/gpt/src/lib.rs
+++ b/ailets-rs/gpt/src/lib.rs
@@ -8,6 +8,7 @@ pub mod handlers;
 pub mod structure_builder;
 
 use actor_io::{AReader, AWriter};
+use embedded_io::Write as _;
 use actor_runtime::{err_to_heap_c_string, ActorRuntime, FfiActorRuntime, StdHandle};
 use dagops::{DagOps, DagOpsTrait, StubDagOps};
 
@@ -214,8 +215,12 @@ pub fn process_gpt_impl<W: embedded_io::Write, D: DagOpsTrait>(
 pub fn execute(runtime: &dyn ActorRuntime) -> Result<(), String> {
     let reader = AReader::new_from_std(runtime, StdHandle::Stdin);
     let writer = AWriter::new_from_std(runtime, StdHandle::Stdout);
-
-    process_gpt_impl(reader, writer, StubDagOps)
+    let result = process_gpt_impl(reader, writer, StubDagOps);
+    if let Err(ref e) = result {
+        let mut log = AWriter::new_from_std(runtime, StdHandle::Log);
+        if log.write_all(format!("{e}\n").as_bytes()).is_err() {}
+    }
+    result
 }
 
 /// # Panics

--- a/ailets-rs/gpt/tests/fcw_tools_test.rs
+++ b/ailets-rs/gpt/tests/fcw_tools_test.rs
@@ -95,7 +95,7 @@ fn inject_tool_calls_to_tools() {
     );
     let expected_tool_input1 = json!({"city": "London"});
     let value_tool_input1 = serde_json::from_str(&value_tool_input1)
-        .expect(&format!("Failed to parse JSON: {value_tool_input1}"));
+        .unwrap_or_else(|_| panic!("Failed to parse JSON: {value_tool_input1}"));
     assert_that!(value_tool_input1, is(equal_to(expected_tool_input1)));
 
     let (handle_toolspec_input1, explain_toolspec_input1, value_toolspec_input1) =
@@ -114,7 +114,7 @@ fn inject_tool_calls_to_tools() {
         }]
     );
     let value_toolspec_input1 = serde_json::from_str(&value_toolspec_input1)
-        .expect(&format!("Failed to parse JSON: {value_toolspec_input1}"));
+        .unwrap_or_else(|_| panic!("Failed to parse JSON: {value_toolspec_input1}"));
     assert_that!(
         value_toolspec_input1,
         is(equal_to(expected_toolspec_input1))
@@ -131,7 +131,7 @@ fn inject_tool_calls_to_tools() {
     );
     let expected_tool_input2 = json!({"days": 5});
     let value_tool_input2 = serde_json::from_str(&value_tool_input2)
-        .expect(&format!("Failed to parse JSON: {value_tool_input2}"));
+        .unwrap_or_else(|_| panic!("Failed to parse JSON: {value_tool_input2}"));
     assert_that!(value_tool_input2, is(equal_to(expected_tool_input2)));
 
     let (handle_toolspec_input2, explain_toolspec_input2, value_toolspec_input2) =
@@ -150,7 +150,7 @@ fn inject_tool_calls_to_tools() {
         }]
     );
     let value_toolspec_input2 = serde_json::from_str(&value_toolspec_input2)
-        .expect(&format!("Failed to parse JSON: {value_toolspec_input2}"));
+        .unwrap_or_else(|_| panic!("Failed to parse JSON: {value_toolspec_input2}"));
     assert_that!(
         value_toolspec_input2,
         is(equal_to(expected_toolspec_input2))
@@ -167,7 +167,7 @@ fn inject_tool_calls_to_tools() {
     //
     let (handle_tool_1, tool_workflow_1, deps_tool_1) =
         tracked_dagops.parse_workflow(&workflows[0]);
-    assert_that!(tool_workflow_1, is(equal_to(format!(".tool.get_weather"))));
+    assert_that!(tool_workflow_1, is(equal_to(".tool.get_weather".to_string())));
     assert_that!(
         deps_tool_1,
         is(equal_to(HashMap::from([(
@@ -178,7 +178,7 @@ fn inject_tool_calls_to_tools() {
 
     let (handle_tool_2, tool_workflow_2, deps_tool_2) =
         tracked_dagops.parse_workflow(&workflows[2]);
-    assert_that!(tool_workflow_2, is(equal_to(format!(".tool.get_forecast"))));
+    assert_that!(tool_workflow_2, is(equal_to(".tool.get_forecast".to_string())));
     assert_that!(
         deps_tool_2,
         is(equal_to(HashMap::from([(
@@ -194,7 +194,7 @@ fn inject_tool_calls_to_tools() {
         tracked_dagops.parse_workflow(&workflows[1]);
     assert_that!(
         aftercall_workflow_1,
-        is(equal_to(format!(".toolcall_to_messages")))
+        is(equal_to(".toolcall_to_messages".to_string()))
     );
     assert_that!(
         deps_aftercall_1,
@@ -208,7 +208,7 @@ fn inject_tool_calls_to_tools() {
         tracked_dagops.parse_workflow(&workflows[3]);
     assert_that!(
         aftercall_workflow_2,
-        is(equal_to(format!(".toolcall_to_messages")))
+        is(equal_to(".toolcall_to_messages".to_string()))
     );
     assert_that!(
         deps_aftercall_2,
@@ -340,9 +340,8 @@ fn multiple_arguments_chunks() {
     // Assert: tool input contains complete arguments
     //
     let (_, _, tool_input_value) = tracked_dagops.parse_value_node(&value_nodes[0]);
-    let tool_input_json: serde_json::Value = serde_json::from_str(&tool_input_value).expect(
-        &format!("Failed to parse tool input JSON: {tool_input_value}"),
-    );
+    let tool_input_json: serde_json::Value = serde_json::from_str(&tool_input_value)
+        .unwrap_or_else(|_| panic!("Failed to parse tool input JSON: {tool_input_value}"));
     let expected_input_json: serde_json::Value =
         serde_json::from_str(expected_complete_args).expect("Failed to parse expected input JSON");
     assert_that!(tool_input_json, is(equal_to(expected_input_json)));
@@ -351,9 +350,8 @@ fn multiple_arguments_chunks() {
     // Assert: tool spec contains complete arguments
     //
     let (_, _, tool_spec_value) = tracked_dagops.parse_value_node(&value_nodes[1]);
-    let tool_spec_json: serde_json::Value = serde_json::from_str(&tool_spec_value).expect(
-        &format!("Failed to parse tool spec JSON: {tool_spec_value}"),
-    );
+    let tool_spec_json: serde_json::Value = serde_json::from_str(&tool_spec_value)
+        .unwrap_or_else(|_| panic!("Failed to parse tool spec JSON: {tool_spec_value}"));
 
     let expected_tool_spec = serde_json::json!([
         {

--- a/ailets-rs/gpt/tests/fcw_tools_test.rs
+++ b/ailets-rs/gpt/tests/fcw_tools_test.rs
@@ -167,7 +167,10 @@ fn inject_tool_calls_to_tools() {
     //
     let (handle_tool_1, tool_workflow_1, deps_tool_1) =
         tracked_dagops.parse_workflow(&workflows[0]);
-    assert_that!(tool_workflow_1, is(equal_to(".tool.get_weather".to_string())));
+    assert_that!(
+        tool_workflow_1,
+        is(equal_to(".tool.get_weather".to_string()))
+    );
     assert_that!(
         deps_tool_1,
         is(equal_to(HashMap::from([(
@@ -178,7 +181,10 @@ fn inject_tool_calls_to_tools() {
 
     let (handle_tool_2, tool_workflow_2, deps_tool_2) =
         tracked_dagops.parse_workflow(&workflows[2]);
-    assert_that!(tool_workflow_2, is(equal_to(".tool.get_forecast".to_string())));
+    assert_that!(
+        tool_workflow_2,
+        is(equal_to(".tool.get_forecast".to_string()))
+    );
     assert_that!(
         deps_tool_2,
         is(equal_to(HashMap::from([(

--- a/ailets-rs/messages_to_markdown/src/lib.rs
+++ b/ailets-rs/messages_to_markdown/src/lib.rs
@@ -3,8 +3,8 @@ pub mod handlers;
 mod structure_builder;
 
 use actor_io::{AReader, AWriter};
-use embedded_io::Write as _;
 use actor_runtime::{err_to_heap_c_string, ActorRuntime, FfiActorRuntime, StdHandle};
+use embedded_io::Write as _;
 use handlers::on_content_text;
 use scan_json::matcher::StructuralPseudoname;
 use scan_json::rjiter::RJiter;

--- a/ailets-rs/messages_to_markdown/src/lib.rs
+++ b/ailets-rs/messages_to_markdown/src/lib.rs
@@ -3,6 +3,7 @@ pub mod handlers;
 mod structure_builder;
 
 use actor_io::{AReader, AWriter};
+use embedded_io::Write as _;
 use actor_runtime::{err_to_heap_c_string, ActorRuntime, FfiActorRuntime, StdHandle};
 use handlers::on_content_text;
 use scan_json::matcher::StructuralPseudoname;
@@ -90,7 +91,12 @@ pub fn messages_to_markdown_impl<W: embedded_io::Write>(
 pub fn execute(runtime: &dyn ActorRuntime) -> Result<(), String> {
     let reader = AReader::new_from_std(runtime, StdHandle::Stdin);
     let writer = AWriter::new_from_std(runtime, StdHandle::Stdout);
-    messages_to_markdown_impl(reader, writer)
+    let result = messages_to_markdown_impl(reader, writer);
+    if let Err(ref e) = result {
+        let mut log = AWriter::new_from_std(runtime, StdHandle::Log);
+        if log.write_all(format!("{e}\n").as_bytes()).is_err() {}
+    }
+    result
 }
 
 /// # Panics

--- a/ailets-rs/messages_to_query/src/lib.rs
+++ b/ailets-rs/messages_to_query/src/lib.rs
@@ -213,7 +213,12 @@ pub fn execute(runtime: &dyn ActorRuntime) -> Result<(), String> {
         }
     };
 
-    process_messages_impl(reader, writer, runtime, env_opts)
+    let result = process_messages_impl(reader, writer, runtime, env_opts);
+    if let Err(ref e) = result {
+        let mut log = AWriter::new_from_std(runtime, StdHandle::Log);
+        if log.write_all(format!("{e}\n").as_bytes()).is_err() {}
+    }
+    result
 }
 
 /// # Panics

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -37,8 +37,8 @@ fn test_text_items() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_item1 = r#"{"role":"system","content":[{"type":"text","text":"You are a helpful assistant who answers in Spanish"}]}"#;
     let expected_item2 = r#"{"role":"user","content":[{"type":"text","text":"Hello!"}]}"#;
@@ -62,8 +62,8 @@ fn special_symbols_in_text() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"user","content":[
         {"type":"text","text":"Here's a \"quoted\" string\nwith newline and unicode: \u1F60 🌟"},
@@ -106,8 +106,8 @@ fn image_as_key() {
     let runtime = VfsActorRuntime::new();
     runtime.add_file(String::from("media/image-as-key-2.png"), b"hello".to_vec());
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8=", "detail": "auto"}}]}]"#;
     let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
@@ -126,8 +126,8 @@ fn mix_text_and_image() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let text_item1 = r#"{"type":"text","text":"Here's an image:"}"#;
     let image_item = r#"{"type":"image_url","image_url":{"url":"https://example.com/image.jpg"}}"#;
@@ -150,8 +150,8 @@ fn regression_one_item_not_two() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"content":[{"type":"text","text":"Hello!"}],"role":"user"}]"#;
     let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
@@ -169,8 +169,8 @@ fn function_call() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"assistant","tool_calls": [
         {"id":"id123","type":"function","function":{"name":"get_weather","arguments":"{\"location\": \"London\", \"unit\": \"celsius\"}"}}
@@ -190,8 +190,8 @@ fn special_symbols_in_function_arguments() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"assistant","tool_calls": [
         {"id":"id123","type":"function","function":{"name":"process_text",
@@ -231,8 +231,8 @@ fn tool_specification() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_tools = format!(
         r#"[{{"type":"function","function":{}}},{{"type":"function","function":{}}}]"#,
@@ -275,8 +275,8 @@ fn toolspec_by_key() {
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
 
     // Assert
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_tools = format!(r#"[{{"type":"function","function":{}}}]"#, toolspec_content);
     let expected_item = r#"[{"role":"user"}]"#.to_string();
@@ -297,8 +297,8 @@ fn tool_role_with_tool_call_id() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
-        .expect("Failed to parse output as JSON");
+    let output_json: Value =
+        serde_json::from_str(writer.get_output().as_str()).expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"tool","tool_call_id":"call_hEUJSGdhP42m1HYos3OTEeCS","content":[
         {"type":"text","text":"{}"},

--- a/ailets-rs/messages_to_query/tests/actor_test.rs
+++ b/ailets-rs/messages_to_query/tests/actor_test.rs
@@ -37,7 +37,7 @@ fn test_text_items() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_item1 = r#"{"role":"system","content":[{"type":"text","text":"You are a helpful assistant who answers in Spanish"}]}"#;
@@ -62,7 +62,7 @@ fn special_symbols_in_text() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"user","content":[
@@ -70,7 +70,7 @@ fn special_symbols_in_text() {
         {"type":"text","text":"Tab\there & escaped quotes: \"hello\""},
         {"type":"text","text":"Backslashes \\ and more \\\\ and control chars \u0007"}
     ]}]"#;
-    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+    let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
@@ -85,13 +85,13 @@ fn image_url_as_is() {
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
     let output_json: Value =
-        serde_json::from_str(&writer.get_output().as_str()).unwrap_or_else(|e| {
+        serde_json::from_str(writer.get_output().as_str()).unwrap_or_else(|e| {
             eprintln!("Output: {}", writer.get_output());
             panic!("Failed to parse output as JSON: {}", e);
         });
 
     let expected_item = r#"[{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}]}]"#;
-    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+    let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
@@ -106,11 +106,11 @@ fn image_as_key() {
     let runtime = VfsActorRuntime::new();
     runtime.add_file(String::from("media/image-as-key-2.png"), b"hello".to_vec());
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role": "user", "content": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,aGVsbG8=", "detail": "auto"}}]}]"#;
-    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+    let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
@@ -126,7 +126,7 @@ fn mix_text_and_image() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let text_item1 = r#"{"type":"text","text":"Here's an image:"}"#;
@@ -150,11 +150,11 @@ fn regression_one_item_not_two() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"content":[{"type":"text","text":"Hello!"}],"role":"user"}]"#;
-    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+    let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
@@ -169,13 +169,13 @@ fn function_call() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"assistant","tool_calls": [
         {"id":"id123","type":"function","function":{"name":"get_weather","arguments":"{\"location\": \"London\", \"unit\": \"celsius\"}"}}
     ]}]"#;
-    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+    let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
@@ -190,14 +190,14 @@ fn special_symbols_in_function_arguments() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"assistant","tool_calls": [
         {"id":"id123","type":"function","function":{"name":"process_text",
           "arguments":"{\"text\": \"Hello\\n\\\"World\\\" 🌟 🎉\u1F60\\\""}}
     ]}]"#;
-    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+    let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }
@@ -231,7 +231,7 @@ fn tool_specification() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_tools = format!(
@@ -239,7 +239,7 @@ fn tool_specification() {
         get_user_name_function, another_function
     );
     let expected_item =
-        format!(r#"[{{"role":"user","content":[{{"type":"text","text":"Hello!"}}]}}]"#);
+        r#"[{"role":"user","content":[{"type":"text","text":"Hello!"}]}]"#.to_string();
     let expected = wrap_boilerplate(&expected_item);
     let expected_with_tools = inject_tools(&expected, &expected_tools);
     let expected_json = serde_json::from_str(&expected_with_tools)
@@ -275,11 +275,11 @@ fn toolspec_by_key() {
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
 
     // Assert
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_tools = format!(r#"[{{"type":"function","function":{}}}]"#, toolspec_content);
-    let expected_item = format!(r#"[{{"role":"user"}}]"#);
+    let expected_item = r#"[{"role":"user"}]"#.to_string();
     let expected = wrap_boilerplate(&expected_item);
     let expected_with_tools = inject_tools(&expected, &expected_tools);
     let expected_json = serde_json::from_str(&expected_with_tools)
@@ -297,14 +297,14 @@ fn tool_role_with_tool_call_id() {
 
     let runtime = VfsActorRuntime::new();
     process_messages_impl(reader, writer.clone(), &runtime, create_empty_env_opts()).unwrap();
-    let output_json: Value = serde_json::from_str(&writer.get_output().as_str())
+    let output_json: Value = serde_json::from_str(writer.get_output().as_str())
         .expect("Failed to parse output as JSON");
 
     let expected_item = r#"[{"role":"tool","tool_call_id":"call_hEUJSGdhP42m1HYos3OTEeCS","content":[
         {"type":"text","text":"{}"},
         {"type":"text","text":"{\"get_user_name\": \"olpa\"}"}
     ]}]"#;
-    let expected_json = serde_json::from_str(&wrap_boilerplate(&expected_item))
+    let expected_json = serde_json::from_str(&wrap_boilerplate(expected_item))
         .expect("Failed to parse expected output as JSON");
     assert_that!(output_json, equal_to(expected_json));
 }

--- a/ailets-rs/messages_to_query/tests/env_opts_test.rs
+++ b/ailets-rs/messages_to_query/tests/env_opts_test.rs
@@ -4,7 +4,6 @@ use actor_runtime_mocked::{RcWriter, VfsActorRuntime};
 use hamcrest::prelude::*;
 use messages_to_query::env_opts::EnvOpts;
 use messages_to_query::structure_builder::StructureBuilder;
-use serde_json;
 use std::collections::HashMap;
 
 #[test]

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -1155,7 +1155,8 @@ fn mix_toolspec_and_other_content() {
     let expected_message2 = r#"{"role":"user",
 "content":[
 {"type":"text","text":"Some text content"}
-]}"#.to_string();
+]}"#
+    .to_string();
     let expected_tools2 = format!(
         r#"[{{"type":"function","function":{}}}]"#,
         toolspec2_content
@@ -1163,7 +1164,8 @@ fn mix_toolspec_and_other_content() {
     let expected_message3 = r#"{"role":"user",
 "tool_calls":[
 {"type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"London\"}"}}
-]}"#.to_string();
+]}"#
+    .to_string();
 
     // Concatenate all parts to build the expected output
     let expected_final = format!(

--- a/ailets-rs/messages_to_query/tests/structure_builder_test.rs
+++ b/ailets-rs/messages_to_query/tests/structure_builder_test.rs
@@ -506,7 +506,7 @@ fn image_key_with_adversarial_content_type() {
     // Only escape enough to have a valid json
     let expected_image_item = format!(
         r#"{{"type":"image_url","image_url":{{"url":"data:\"\"image/png\u0000\\/\"';{}{};base64,aGVsbG8="}}}}"#,
-        '\u{202E}' as char, '\u{2028}' as char
+        '\u{202E}', '\u{2028}'
     );
     assert_that!(
         writer.get_output(),
@@ -812,13 +812,13 @@ fn happy_path_toolspecs() {
     }"#;
 
     let data1 = get_user_name_fn.as_bytes();
-    let mut cursor1 = data1.as_ref();
+    let mut cursor1 = data1;
     let mut buffer1 = [0u8; 1024];
     let rjiter1 = scan_json::RJiter::new(&mut cursor1, &mut buffer1);
     let mut rjiter1 = rjiter1;
 
     let data2 = another_function_fn.as_bytes();
-    let mut cursor2 = data2.as_ref();
+    let mut cursor2 = data2;
     let mut buffer2 = [0u8; 1024];
     let rjiter2 = scan_json::RJiter::new(&mut cursor2, &mut buffer2);
     let mut rjiter2 = rjiter2;
@@ -869,7 +869,7 @@ fn happy_path_toolspecs() {
     }}]"#
     );
     let expected_item =
-        format!(r#"{{"role":"user",_NL_"content":[{{"type":"text","text":"Hello!"}}]}}"#);
+        r#"{"role":"user",_NL_"content":[{"type":"text","text":"Hello!"}]}"#.to_string();
     let expected = wrap_boilerplate(&expected_item);
     let expected_with_tools = inject_tools(&expected, &expected_tools);
     let expected_json = serde_json::from_str(&expected_with_tools)
@@ -900,7 +900,7 @@ fn toolspec_by_key() {
     );
 
     let data = toolspec_content.as_bytes();
-    let mut cursor = data.as_ref();
+    let mut cursor = data;
     let mut buffer = [0u8; 1024];
     let mut rjiter = scan_json::RJiter::new(&mut cursor, &mut buffer);
 
@@ -998,19 +998,19 @@ fn several_toolspecs_to_one_block() {
     let toolspec3_content = r#"{"name":"tool3","description":"Third tool"}"#;
 
     let data1 = toolspec1_content.as_bytes();
-    let mut cursor1 = data1.as_ref();
+    let mut cursor1 = data1;
     let mut buffer1 = [0u8; 1024];
     let rjiter1 = scan_json::RJiter::new(&mut cursor1, &mut buffer1);
     let mut rjiter1 = rjiter1;
 
     let data2 = toolspec2_content.as_bytes();
-    let mut cursor2 = data2.as_ref();
+    let mut cursor2 = data2;
     let mut buffer2 = [0u8; 1024];
     let rjiter2 = scan_json::RJiter::new(&mut cursor2, &mut buffer2);
     let mut rjiter2 = rjiter2;
 
     let data3 = toolspec3_content.as_bytes();
-    let mut cursor3 = data3.as_ref();
+    let mut cursor3 = data3;
     let mut buffer3 = [0u8; 1024];
     let rjiter3 = scan_json::RJiter::new(&mut cursor3, &mut buffer3);
     let mut rjiter3 = rjiter3;
@@ -1073,13 +1073,13 @@ fn mix_toolspec_and_other_content() {
     let toolspec2_content = r#"{"name":"tool2","description":"Second tool"}"#;
 
     let data1 = toolspec1_content.as_bytes();
-    let mut cursor1 = data1.as_ref();
+    let mut cursor1 = data1;
     let mut buffer1 = [0u8; 1024];
     let rjiter1 = scan_json::RJiter::new(&mut cursor1, &mut buffer1);
     let mut rjiter1 = rjiter1;
 
     let data2 = toolspec2_content.as_bytes();
-    let mut cursor2 = data2.as_ref();
+    let mut cursor2 = data2;
     let mut buffer2 = [0u8; 1024];
     let rjiter2 = scan_json::RJiter::new(&mut cursor2, &mut buffer2);
     let mut rjiter2 = rjiter2;
@@ -1152,22 +1152,18 @@ fn mix_toolspec_and_other_content() {
         r#"[{{"type":"function","function":{}}}]"#,
         toolspec1_content
     );
-    let expected_message2 = format!(
-        r#"{{"role":"user",
+    let expected_message2 = r#"{"role":"user",
 "content":[
-{{"type":"text","text":"Some text content"}}
-]}}"#
-    );
+{"type":"text","text":"Some text content"}
+]}"#.to_string();
     let expected_tools2 = format!(
         r#"[{{"type":"function","function":{}}}]"#,
         toolspec2_content
     );
-    let expected_message3 = format!(
-        r#"{{"role":"user",
+    let expected_message3 = r#"{"role":"user",
 "tool_calls":[
-{{"type":"function","function":{{"name":"get_weather","arguments":"{{\"location\":\"London\"}}"}}}}
-]}}"#
-    );
+{"type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"London\"}"}}
+]}"#.to_string();
 
     // Concatenate all parts to build the expected output
     let expected_final = format!(

--- a/ailets-rs/query/src/lib.rs
+++ b/ailets-rs/query/src/lib.rs
@@ -114,7 +114,12 @@ fn perform_request(
 pub fn execute(runtime: &dyn ActorRuntime) -> Result<(), String> {
     let reader = AReader::new_from_std(runtime, StdHandle::Stdin);
     let writer = AWriter::new_from_std(runtime, StdHandle::Stdout);
-    execute_impl(reader, writer, &ureq::Agent::new_with_defaults())
+    let result = execute_impl(reader, writer, &ureq::Agent::new_with_defaults());
+    if let Err(ref e) = result {
+        let mut log = AWriter::new_from_std(runtime, StdHandle::Log);
+        if writeln!(log, "{e}").is_err() {}
+    }
+    result
 }
 
 /// Like [`execute`] but uses a caller-supplied agent, enabling transport injection for tests.


### PR DESCRIPTION
- cat `<node>[:<stream>]` selects a stream by name or numeric fd
- Named aliases: stdout, stderr/log, stdin, env, metrics, trace
- Node errors are written to StdHandle::Log in all actors

close #274
